### PR TITLE
chore: better cli usage output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 all: build
 
-build:
-	go build -o ./bin/recovery-tool ./ && chmod +x ./bin/*
+build: build-win build-mac build-linux
 
 build-win:
 	GOOS=windows GOARCH=amd64 go build -trimpath -o ./bin/recovery-tool.exe ./

--- a/main.go
+++ b/main.go
@@ -69,13 +69,13 @@ func main() {
 	flag.Parse()
 	files := flag.Args()
 	if len(files) < 1 {
-		fmt.Println("Please supply some input files on the command line.")
-		flag.Usage()
+		fmt.Println("Please supply some input files on the command line. \nExample: recovery-tool.exe [-flags] file1.json file2.json ... \n\nOptional flags:")
+		flag.PrintDefaults()
 		return
 	}
 	if *vaultID == "" {
 		// flag.Usage()
-		fmt.Println("No --vault-id was specified, so the tool will just list out the vault IDs available.")
+		fmt.Println("No --vault-id was specified, so the tool will just list out the available vault IDs.")
 	}
 
 	println()


### PR DESCRIPTION
## v2.2.1

Cosmetic change.
Print a better usage string when no args are given.

### Example

```
Please supply some input files on the command line. 
Example: recovery-tool.exe [-flags] file1.json file2.json ... 

Optional flags:
  -export string
    	(Optional) Path to export Ethereum wallet keystore file.
  -nonce int
    	(Optional) Reshare Nonce override. Try it if the tool advises you to do so. (default -1)
  -password string
    	(Optional) Encryption password for the Ethereum wallet keystore; use with --export
  -threshold int
    	(Optional) Vault Quorum (Threshold) override. Try it if the tool advises you to do so.
  -vault-id string
    	(Optional) The vault id to export the keys for.
```

### Changes

- [chore(main): print a better usage string when no args are given](https://github.com/IoFinnet/io-vault-disaster-recovery-cli/commit/856b364848164edfd2d4efb8dc6a71f18517df5c)
- [chore(Makefile): vanilla make builds all archs](https://github.com/IoFinnet/io-vault-disaster-recovery-cli/commit/cab1ac654f7a908b6d1ea7dcacd72b9983a5f449)