### PR TITLE
feat(scripts/bittensor): add bittensor recovery tool

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -27,7 +27,7 @@ func Banner() string {
 	b := "\n"
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s     io.finnet Key Recovery Tool     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
-	b += fmt.Sprintf("%s%s               v5.1.0                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
+	b += fmt.Sprintf("%s%s               v5.2.0                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += "\n"
 	return b

--- a/scripts/bittensor-recovery-script/README.md
+++ b/scripts/bittensor-recovery-script/README.md
@@ -1,0 +1,134 @@
+# Bittensor Disaster Recovery Transfer Tool
+
+A command-line tool for transferring **TAO** (Bittensor) tokens using EdDSA/Ed25519 keypairs. This tool allows you to:
+  - Import Ed25519 keypairs in raw hex format for disaster recovery
+- Derive the correct Bittensor SS58 wallet address
+- Create and sign TAO transfer transactions
+- Broadcast transactions to the Bittensor Substrate network
+
+## Prerequisites
+
+- **Node.js 20** or higher
+- **npm** or **yarn**
+
+## Installation
+
+1. Clone this repository or download the files.
+2. Install dependencies:
+  ```bash
+   npm install
+   ```
+
+## Running the Tool
+
+Run the script using **tsx** (TypeScript Execution):
+
+```bash
+npx tsx main.ts
+```
+
+## Usage Flow
+
+1. Enter your **EdDSA keypair** in raw hex format:
+  - Public key (64 hex characters)
+- Private key (64 hex characters)
+2. Verify your **derived SS58 address**.
+3. Enter transaction details:
+  - Destination Bittensor wallet address (SS58 format)
+- Amount of TAO to transfer
+4. Review the transaction details.
+5. Sign and broadcast the transaction to the network.
+
+---
+
+## Example Keys Format
+
+The tool expects your Ed25519 public and private keys in raw hex format (32 bytes each, 64 hex characters total). Example:
+
+  - **Public key**:
+`d6c1b2d7c4e47e72d937f64c90bc2e3775d40a8e38c2990c4397dcb1b0d6a512`
+
+- **Private key**:
+`32e1f1725190e14500a865a4dae637129d7959025164a9c0f58247c4d00ebd12`
+
+---
+
+## Security Notes
+
+- Your private key is **never stored or transmitted**.
+- The tool can run **offline**, except for broadcasting the transaction.
+- Always verify the derived wallet address before proceeding.
+- Use the **testnet** environment first to ensure the keys and flow are correct.
+
+---
+
+## Network Configuration
+
+You can specify a Bittensor node endpoint for broadcasting transactions:
+
+  - **Mainnet**: `wss://entrypoint-finney.opentensor.ai:443`
+- **Testnet**: Replace with the appropriate endpoint.
+
+  You will be prompted to enter the endpoint during execution.
+
+---
+
+## Offline Usage
+
+The tool can be run offline for:
+- Keypair recovery and SS58 address derivation.
+- Transaction preparation and signing.
+
+**Note**: Broadcasting requires an active connection to the Bittensor Substrate network.
+
+---
+
+## Error Handling
+
+The tool includes validation for:
+- Private and public key format (32 bytes / 64 hex characters).
+- SS58 address format (Bittensor prefix `42`).
+- Valid TAO transfer amounts.
+- Network connectivity issues when broadcasting.
+
+  If a mismatch occurs between the derived public key and provided public key, the tool will alert you and stop execution.
+
+---
+
+## Example Workflow
+
+### 1. Run the Tool
+
+  ```bash
+npm run start
+```
+
+### 2. Enter Keypair
+
+  ```plaintext
+Public Key (64 hex chars): d6c1b2d7c4e47e72d937f64c90bc2e3775d40a8e38c2990c4397dcb1b0d6a512
+Private Key (64 hex chars): 32e1f1725190e14500a865a4dae637129d7959025164a9c0f58247c4d00ebd12
+```
+
+### 3. Verify Derived Address
+
+  ```plaintext
+Derived Address (SS58): 5DDRNSii3jUdb4yWot6ZvzeXg3DtUG7vWXQzVJkbVnZKYqUG
+```
+
+### 4. Enter Transaction Details & Broadcast
+
+  ```plaintext
+Enter the destination address: 5Fexample1234567890addressHere
+Enter the amount of TAO to transfer: 1.0
+Enter the endpoint (default: wss://entrypoint-finney.opentensor.ai:443): 
+```
+
+---
+
+## Troubleshooting
+
+- **Invalid Signature Error**: Ensure that the public key matches the private key. If using an MPC system, verify the keys align correctly.
+- **Address Mismatch**: The derived address must match the expected address. Double-check the private key input.
+- **Network Issues**: Verify the Substrate endpoint URL and your internet connection.
+

--- a/scripts/bittensor-recovery-script/main.ts
+++ b/scripts/bittensor-recovery-script/main.ts
@@ -3,6 +3,7 @@ import readlineSync from 'readline-sync';
 import { BN } from 'bn.js';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import * as ed from '@noble/ed25519';
+import { bytesToNumberBE } from '@noble/curves/abstract/utils';
 import { sha512 } from '@noble/hashes/sha512';
 
 // Constants
@@ -33,9 +34,13 @@ async function transferFunds(privateKey: string, destination: string, amount: st
 
   // Prepare the private key
   let privateKeyBytes = Buffer.from(privateKey, 'hex');
+  if (privateKeyBytes.length !== 32) {
+    throw new Error('Private key must be 32 bytes');
+  }
 
   // Derive the public key from the private key
-  const derivedPublicKeyBytes = await ed.getPublicKey(privateKeyBytes);
+  const derivedPublicKeyBytes = ed.ExtendedPoint.BASE.multiply(bytesToNumberBE(privateKeyBytes)).toRawBytes();
+  console.log("Derived Public Key (Hex):", Buffer.from(derivedPublicKeyBytes).toString('hex'));
 
   // Combine private and public keys to create the Ed25519 secret key
   const secretKey = Buffer.concat([privateKeyBytes, Buffer.from(derivedPublicKeyBytes)]);

--- a/scripts/bittensor-recovery-script/main.ts
+++ b/scripts/bittensor-recovery-script/main.ts
@@ -24,7 +24,6 @@ ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
  * @param endpoint - The WebSocket endpoint for the Bittensor network.
  */
 async function transferFunds(privateKeyHex: string, destination: string, amount: string, endpoint: string) {
-  console.log("Initializing cryptography...");
   await cryptoWaitReady();
 
   console.log("Connecting to the Bittensor network...");

--- a/scripts/bittensor-recovery-script/main.ts
+++ b/scripts/bittensor-recovery-script/main.ts
@@ -6,7 +6,7 @@ import { Signer, SignerPayloadRaw, SignerResult } from '@polkadot/types/types';
 import * as ed from '@noble/ed25519';
 import { bytesToNumberBE, bytesToNumberLE, numberToBytesLE } from '@noble/curves/abstract/utils';
 import { sha512 } from '@noble/hashes/sha512';
-import {webcrypto} from "crypto";
+import { webcrypto } from 'crypto';
 
 // Constants
 const DECIMALS = 9;

--- a/scripts/bittensor-recovery-script/main.ts
+++ b/scripts/bittensor-recovery-script/main.ts
@@ -1,0 +1,133 @@
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
+import readlineSync from 'readline-sync';
+import { BN } from 'bn.js';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+
+// Constants
+const DECIMALS = 9;
+const PLANCK = new BN(10).pow(new BN(DECIMALS)); // 1 unit = 10^9 Planck
+const SS58_FORMAT = 42; // SS58 address format for the Bittensor network
+
+// Assign SHA512 hash function for noble-ed25519 compatibility
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+
+/**
+ * Transfers funds on the Bittensor network.
+ * @param privateKey - The raw Ed25519 private key in hex format.
+ * @param destination - The SS58 destination address.
+ * @param amount - The amount to transfer in Planck units.
+ * @param endpoint - The WebSocket endpoint for the Bittensor network.
+ */
+async function transferFunds(privateKey: string, destination: string, amount: string, endpoint: string) {
+  console.log("Initializing cryptography...");
+  await cryptoWaitReady();
+
+  console.log("Connecting to the Bittensor network...");
+  const provider = new WsProvider(endpoint);
+  const api = await ApiPromise.create({ provider });
+
+  console.log("Creating keyring...");
+  const keyring = new Keyring({ type: 'ed25519', ss58Format: SS58_FORMAT });
+
+  // Prepare the private key
+  let privateKeyBytes = Buffer.from(privateKey, 'hex');
+
+  // Derive the public key from the private key
+  const derivedPublicKeyBytes = await ed.getPublicKey(privateKeyBytes);
+
+  // Combine private and public keys to create the Ed25519 secret key
+  const secretKey = Buffer.concat([privateKeyBytes, Buffer.from(derivedPublicKeyBytes)]);
+
+  // Add the keypair to the keyring
+  const keyPair = keyring.addFromPair({
+    publicKey: derivedPublicKeyBytes,
+    secretKey: secretKey,
+  });
+
+  console.log("Derived Address (SS58):", keyPair.address);
+
+  console.log("Creating transfer transaction...");
+  const transfer = api.tx.balances.transferKeepAlive(destination, amount);
+
+  console.log("Signing and sending transaction...");
+  const hash = await transfer.signAndSend(keyPair, { nonce: -1 });
+  console.log(`Transaction sent successfully. Hash: ${hash.toHex()}`);
+
+  await api.disconnect();
+}
+
+/**
+ * Validates if the input string is a valid hex string of the given byte length.
+ * @param input - The input string to validate.
+ * @param length - The expected byte length.
+ * @returns True if the input is a valid hex string; otherwise, false.
+ */
+function validateHex(input: string, length: number): boolean {
+  return input.length === length * 2 && /^[0-9a-fA-F]+$/.test(input);
+}
+
+/**
+ * Validates if the input is a valid SS58 address.
+ * @param address - The SS58 address to validate.
+ * @returns True if the address is valid; otherwise, false.
+ */
+function validateAddress(address: string): boolean {
+  return address.length === 48 && /^[1-9A-HJ-NP-Za-km-z]+$/.test(address);
+}
+
+/**
+ * Validates if the input is a positive numeric amount.
+ * @param amount - The input amount.
+ * @returns True if the amount is valid; otherwise, false.
+ */
+function validateAmount(amount: string): boolean {
+  const num = Number(amount);
+  return !isNaN(num) && num > 0;
+}
+
+async function main() {
+  console.log('Bittensor Transfer Tool\n');
+
+  let privateKey;
+  do {
+    privateKey = readlineSync.question('Private Key (64 hex chars): ', { hideEchoBack: true });
+    if (!validateHex(privateKey, 32)) {
+      console.log('Invalid private key format. Must be 64 hexadecimal characters.');
+    }
+  } while (!validateHex(privateKey, 32));
+
+  let destination;
+  do {
+    destination = readlineSync.question('Enter the destination address: ');
+    if (!validateAddress(destination)) {
+      console.log('Invalid address format. Must be a valid Bittensor address.');
+    }
+  } while (!validateAddress(destination));
+
+  let amount;
+  do {
+    amount = readlineSync.question('Enter the amount to transfer: ');
+    if (!validateAmount(amount)) {
+      console.log('Invalid amount. Must be a positive number.');
+    }
+  } while (!validateAmount(amount));
+
+  const endpoint = readlineSync.question(
+    'Enter the endpoint (e.g., wss://entrypoint-finney.opentensor.ai:443): ',
+    { defaultInput: 'wss://entrypoint-finney.opentensor.ai:443' }
+  );
+
+  console.log('\nProcessing your transaction...\n');
+  try {
+    // Convert amount to Planck units (smallest denomination)
+    const amountInPlanck = new BN(Number(amount) * Number(PLANCK));
+    await transferFunds(privateKey, destination, amountInPlanck.toString(), endpoint);
+    console.log('Transaction completed successfully.');
+  } catch (error) {
+    console.error('Error processing transaction:', error.message);
+  }
+}
+
+main();

--- a/scripts/bittensor-recovery-script/package-lock.json
+++ b/scripts/bittensor-recovery-script/package-lock.json
@@ -16,6 +16,7 @@
         "readline-sync": "^1.4.10"
       },
       "devDependencies": {
+        "@types/node": "^22.10.2",
         "tsx": "^4.19.2"
       }
     },
@@ -1058,6 +1059,7 @@
       "version": "22.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
       "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }

--- a/scripts/bittensor-recovery-script/package-lock.json
+++ b/scripts/bittensor-recovery-script/package-lock.json
@@ -1,0 +1,1427 @@
+{
+  "name": "bittensor-recovery-script",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bittensor-recovery-script",
+      "version": "1.0.0",
+      "dependencies": {
+        "@noble/ed25519": "^2.1.0",
+        "@polkadot/api": "^15.0.2",
+        "@polkadot/util-crypto": "^13.2.3",
+        "bn.js": "^5.2.1",
+        "elliptic": "^6.6.1",
+        "readline-sync": "^1.4.10"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-15.0.2.tgz",
+      "integrity": "sha512-CA8Pq2Gsz2MJvpkpIVNzaBs2eJGCr0sEodAb0vTOZW/ZlIDHcBWyWq3KXE+lBMWVzYBEC4Vz6MafNgq6Bsshlw==",
+      "dependencies": {
+        "@polkadot/api-augment": "15.0.2",
+        "@polkadot/api-base": "15.0.2",
+        "@polkadot/api-derive": "15.0.2",
+        "@polkadot/keyring": "^13.2.3",
+        "@polkadot/rpc-augment": "15.0.2",
+        "@polkadot/rpc-core": "15.0.2",
+        "@polkadot/rpc-provider": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-augment": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/types-create": "15.0.2",
+        "@polkadot/types-known": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "@polkadot/util-crypto": "^13.2.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-15.0.2.tgz",
+      "integrity": "sha512-7qtfTihLKS7cT2kEsd8Y1+MJ+2n4Sl0y9BHuPhdNfKcDbGwCxIB7JzXNujww4Is4bF7w1lXcM2U0E/XwJi1BbQ==",
+      "dependencies": {
+        "@polkadot/api-base": "15.0.2",
+        "@polkadot/rpc-augment": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-augment": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-15.0.2.tgz",
+      "integrity": "sha512-5++EjpuCxzmrL2JJj511RrPK+IovuIQa8DJhyOp62VDMXPkqS/O6Df5wjYzQh/ftT1ZysftXqJAUA/LSUsH+2g==",
+      "dependencies": {
+        "@polkadot/rpc-core": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-15.0.2.tgz",
+      "integrity": "sha512-nD8hXZxEv2/wuhjMmVP09lTAYd8inNgrLpLGUR+7hBQeVEQQTdNatkqMKpNIOk2MO46mtUK35NepvDBK9DWZzA==",
+      "dependencies": {
+        "@polkadot/api": "15.0.2",
+        "@polkadot/api-augment": "15.0.2",
+        "@polkadot/api-base": "15.0.2",
+        "@polkadot/rpc-core": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "@polkadot/util-crypto": "^13.2.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.2.3.tgz",
+      "integrity": "sha512-pgTo6DXNXub0wGD+MnVHYhKxf80Jl+QMOCb818ioGdXz++Uw4mTueFAwtB+N7TGo0HafhChUiNJDxFdlDkcAng==",
+      "dependencies": {
+        "@polkadot/util": "13.2.3",
+        "@polkadot/util-crypto": "13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.2.3",
+        "@polkadot/util-crypto": "13.2.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.2.3.tgz",
+      "integrity": "sha512-mG+zkXg/33AyPrkv2xBbAo3LBUwOwBn6qznBU/4jxiZPnVvCwMaxE7xHM22B5riItbNJ169FXv3wy0v6ZmkFbw==",
+      "dependencies": {
+        "@polkadot/util": "13.2.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-15.0.2.tgz",
+      "integrity": "sha512-of88GdzsOs15HP+Gowh4G/iKKFkCNIeF0Wes8LiONfn+j2TmWt8blbyGhrIZZeApzbFUDFjnxUPGT40uWJcMpw==",
+      "dependencies": {
+        "@polkadot/rpc-core": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-15.0.2.tgz",
+      "integrity": "sha512-KOUnfXOAFCN0N23sEbS+FzXhX88JCvJst/nKzO9+q67NgYBEqgcaoG4tqt/VVedgkNi0kA7WAA3wyjt5UYMnrg==",
+      "dependencies": {
+        "@polkadot/rpc-augment": "15.0.2",
+        "@polkadot/rpc-provider": "15.0.2",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-15.0.2.tgz",
+      "integrity": "sha512-BwLP8gNskzqtQ2kMk+EX6WK4d9TU0XJ/nJg0TKC2dX5sSTpTF2JQIYp1wuOik4rKNXIU/1hKaDSSylMJj7AHeQ==",
+      "dependencies": {
+        "@polkadot/keyring": "^13.2.3",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-support": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "@polkadot/util-crypto": "^13.2.3",
+        "@polkadot/x-fetch": "^13.2.3",
+        "@polkadot/x-global": "^13.2.3",
+        "@polkadot/x-ws": "^13.2.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-15.0.2.tgz",
+      "integrity": "sha512-6gZBnuXU58hQAXWI2daED2OaQwFMxbQdkE8HVGMovMobEf0PxPfIqf+GdnVmWbe09EU9mv2gCWBcdnvHSRBlQg==",
+      "dependencies": {
+        "@polkadot/keyring": "^13.2.3",
+        "@polkadot/types-augment": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/types-create": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "@polkadot/util-crypto": "^13.2.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-15.0.2.tgz",
+      "integrity": "sha512-UiFJVEYML30+V9GdFAHPbA3s4MVQTL1CevsZMnX0+ApvlgEHJMZnVFfYF7jL2bl9BcUYM/zoxEAhj2MpqFFfxw==",
+      "dependencies": {
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-15.0.2.tgz",
+      "integrity": "sha512-44Q40p1rl0t7Bl1QUamewqXNVPway9xgqByyifv6ODSGhtt+lFoarb3U4JzqRUuuK0PP57ePB0L8q81Totxeew==",
+      "dependencies": {
+        "@polkadot/util": "^13.2.3",
+        "@polkadot/x-bigint": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-15.0.2.tgz",
+      "integrity": "sha512-YhpcqbH3oI87PkgrV6Fez9jWDqFIep0KcS1YWQcwc9gsBNnuour80t2AAK41/tqAYwOZi6tpJwIevnEhVkxFYA==",
+      "dependencies": {
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-15.0.2.tgz",
+      "integrity": "sha512-SyBo4xBoesHYiEfdW/nOgaftKgM7+puBWqQXq1Euz0MM5LDLjxBw22Srgk9ulGM6l9MsekIwCyX8geJ6/6J3Cg==",
+      "dependencies": {
+        "@polkadot/networks": "^13.2.3",
+        "@polkadot/types": "15.0.2",
+        "@polkadot/types-codec": "15.0.2",
+        "@polkadot/types-create": "15.0.2",
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-15.0.2.tgz",
+      "integrity": "sha512-I7Im/4K2/XDZ1LfeQeeNyvIkfvozIPQs8K1/nsICDOmBbvIsjxSeKWHOcFDMJ8AlPEer6bqNQavOyZA/pg9R/Q==",
+      "dependencies": {
+        "@polkadot/util": "^13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.2.3.tgz",
+      "integrity": "sha512-pioNnsig3qHXrfOKMe4Yqos8B8N3/EZUpS+WfTpWnn1VjYban/0GrTXeavPlAwggnY27b8fS6rBzQBhnVYDw8g==",
+      "dependencies": {
+        "@polkadot/x-bigint": "13.2.3",
+        "@polkadot/x-global": "13.2.3",
+        "@polkadot/x-textdecoder": "13.2.3",
+        "@polkadot/x-textencoder": "13.2.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.2.3.tgz",
+      "integrity": "sha512-5sbggmLbn5eiuVMyPROPlT5roHRqdKHOfSpioNbGvGIZ1qIWVoC1RfsK0NWJOVGDzy6DpQe0KYT/kgcU5Xsrzw==",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "13.2.3",
+        "@polkadot/util": "13.2.3",
+        "@polkadot/wasm-crypto": "^7.4.1",
+        "@polkadot/wasm-util": "^7.4.1",
+        "@polkadot/x-bigint": "13.2.3",
+        "@polkadot/x-randomvalues": "13.2.3",
+        "@scure/base": "^1.1.7",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.2.3"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.4.1.tgz",
+      "integrity": "sha512-tdkJaV453tezBxhF39r4oeG0A39sPKGDJmN81LYLf+Fihb7astzwju+u75BRmDrHZjZIv00un3razJEWCxze6g==",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.4.1",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.4.1.tgz",
+      "integrity": "sha512-kHN/kF7hYxm1y0WeFLWeWir6oTzvcFmR4N8fJJokR+ajYbdmrafPN+6iLgQVbhZnDdxyv9jWDuRRsDnBx8tPMQ==",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.4.1",
+        "@polkadot/wasm-crypto-asmjs": "7.4.1",
+        "@polkadot/wasm-crypto-init": "7.4.1",
+        "@polkadot/wasm-crypto-wasm": "7.4.1",
+        "@polkadot/wasm-util": "7.4.1",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.4.1.tgz",
+      "integrity": "sha512-pwU8QXhUW7IberyHJIQr37IhbB6DPkCG5FhozCiNTq4vFBsFPjm9q8aZh7oX1QHQaiAZa2m2/VjIVE+FHGbvHQ==",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.4.1.tgz",
+      "integrity": "sha512-AVka33+f7MvXEEIGq5U0dhaA2SaXMXnxVCQyhJTaCnJ5bRDj0Xlm3ijwDEQUiaDql7EikbkkRtmlvs95eSUWYQ==",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.4.1",
+        "@polkadot/wasm-crypto-asmjs": "7.4.1",
+        "@polkadot/wasm-crypto-wasm": "7.4.1",
+        "@polkadot/wasm-util": "7.4.1",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.4.1.tgz",
+      "integrity": "sha512-PE1OAoupFR0ZOV2O8tr7D1FEUAwaggzxtfs3Aa5gr+yxlSOaWUKeqsOYe1KdrcjmZVV3iINEAXxgrbzCmiuONg==",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.4.1",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.4.1.tgz",
+      "integrity": "sha512-RAcxNFf3zzpkr+LX/ItAsvj+QyM56TomJ0xjUMo4wKkHjwsxkz4dWJtx5knIgQz/OthqSDMR59VNEycQeNuXzA==",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.2.3.tgz",
+      "integrity": "sha512-VKgEAh0LsxTd/Hg517Tt5ZU4CySjBwMpaojbkjgv3fOdg1cN7t4eFEUxpyj7mlO0cp22SzDh7nmy4TO98qhLQA==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.2.3.tgz",
+      "integrity": "sha512-7Nmk+8ieEGzz43nc1rX6nH3rQo6rhGmAaIXJWnXY9gOHY0k1me1bJYbP+xDdh8vcLh8eY3D1sESUwG6QYZW2lg==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.2.3.tgz",
+      "integrity": "sha512-7MYQIAEwBkRcNrgqac5PbB0kNPlI6ISJEy6/Nb+crj8BFjQ8rf11PF49fq0QsvDeuYM1aNLigrvYZNptQs4lbw==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.2.3.tgz",
+      "integrity": "sha512-Zf0GTfLmVk+VzPUmcQSpXjjmFzMTjPhXoLuIoE7xIu73T+vQ+TX9j7DvorN6bIRsnZ9l1SyTZsSf/NTjNZKIZg==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.2.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.2.3.tgz",
+      "integrity": "sha512-i8hRXPtGknmdm3FYv6/94I52VXHJZa5sgYNw1+Hqb4Jqmq4awUjea35CKXd/+aw70Qn8Ngg31l2GoiH494fa+Q==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.2.3.tgz",
+      "integrity": "sha512-wJI3Bb/dC4zyBXJFm5+ZhyBXWoI5wvP8k8qX0/ZC0PQsgSAqs7LVhiofk4Wd94n0P41W5re58LrGXLyziSAshw==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.2.3.tgz",
+      "integrity": "sha512-Y6MTAWgcnrnx/LkBx65X3ZyoJH5EFj3tXtflRoKg1+PLHSLuNBV7Wi5mLcE70z4e5c+4hgBbLq+8SqCqzFtSPw==",
+      "dependencies": {
+        "@polkadot/x-global": "13.2.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.1.tgz",
+      "integrity": "sha512-GoafTgm/Jey9E4Xlj4Z5ZBt/H4drH2CNq8VrAro80rtoznrXnFDNVivLQzZN0Xaj2g8YXSn9pC9Oc9IovYZJXw==",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.8.1.tgz",
+      "integrity": "sha512-WkqXvuLWL1g136nxAoGkclybsVpo8claHeBl/8iA99ECAk4pWLtoCh8PoYrFEE1HfY4rk+A0krPybDlcDa/G4g==",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ=="
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "optional": true
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/bittensor-recovery-script/package.json
+++ b/scripts/bittensor-recovery-script/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bittensor-recovery-script",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "main.ts",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@noble/ed25519": "^2.1.0",
+    "@polkadot/api": "^15.0.2",
+    "@polkadot/util-crypto": "^13.2.3",
+    "bn.js": "^5.2.1",
+    "elliptic": "^6.6.1",
+    "readline-sync": "^1.4.10"
+  },
+  "author": "io.finnet group, inc.",
+  "description": "A tool for converting private keys into 12-word mnemonic seeds for disaster recovery.",
+  "devDependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/scripts/bittensor-recovery-script/package.json
+++ b/scripts/bittensor-recovery-script/package.json
@@ -18,6 +18,7 @@
   "author": "io finnet group, inc.",
   "description": "A tool for converting private keys into 12-word mnemonic seeds for disaster recovery.",
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "tsx": "^4.19.2"
   }
 }

--- a/scripts/bittensor-recovery-script/package.json
+++ b/scripts/bittensor-recovery-script/package.json
@@ -15,7 +15,7 @@
     "elliptic": "^6.6.1",
     "readline-sync": "^1.4.10"
   },
-  "author": "io.finnet group, inc.",
+  "author": "io finnet group, inc.",
   "description": "A tool for converting private keys into 12-word mnemonic seeds for disaster recovery.",
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/scripts/bittensor-recovery-script/tsconfig.json
+++ b/scripts/bittensor-recovery-script/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/scripts/xrpl-tool/main.ts
+++ b/scripts/xrpl-tool/main.ts
@@ -2,7 +2,7 @@ import { Client, decode, encode, encodeForSigning, Transaction, verifySignature,
 import readlineSync from 'readline-sync';
 import { webcrypto } from 'crypto';
 import * as ed from '@noble/ed25519';
-import { bytesToNumberBE, bytesToNumberLE, numberToBytesBE, numberToBytesLE } from '@noble/curves/abstract/utils';
+import { bytesToNumberBE, bytesToNumberLE, numberToBytesLE } from '@noble/curves/abstract/utils';
 import { hashSignedTx } from 'xrpl/dist/npm/utils/hashes';
 import { sha512 } from '@noble/hashes/sha512';
 

--- a/scripts/xrpl-tool/package-lock.json
+++ b/scripts/xrpl-tool/package-lock.json
@@ -12,6 +12,9 @@
         "@noble/hashes": "^1.6.1",
         "readline-sync": "^1.4.10",
         "xrpl": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2"
       }
     },
     "node_modules/@noble/curves": {
@@ -96,6 +99,16 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@xrplf/isomorphic": {
@@ -186,6 +199,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/scripts/xrpl-tool/package.json
+++ b/scripts/xrpl-tool/package.json
@@ -13,7 +13,7 @@
     "readline-sync": "^1.4.10",
     "xrpl": "^4.0.0"
   },
-  "author": "io.finnet group, inc.",
+  "author": "io finnet group, inc.",
   "description": "Loads in a scalar format EDDSA keypair for onchain recovery of XRPL assets.",
   "devDependencies": {
     "@types/node": "^22.10.2"

--- a/scripts/xrpl-tool/package.json
+++ b/scripts/xrpl-tool/package.json
@@ -14,5 +14,8 @@
     "xrpl": "^4.0.0"
   },
   "author": "io.finnet group, inc.",
-  "description": "Loads in a scalar format EDDSA keypair for onchain recovery of XRPL assets."
+  "description": "Loads in a scalar format EDDSA keypair for onchain recovery of XRPL assets.",
+  "devDependencies": {
+    "@types/node": "^22.10.2"
+  }
 }

--- a/scripts/xrpl-tool/tsconfig.json
+++ b/scripts/xrpl-tool/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "moduleResolution": "nodenext"
+  }
+}


### PR DESCRIPTION
### Pull Request: Add Bittensor Recovery Script

#### Summary
This PR introduces a new script under `scripts/bittensor-recovery-script` to facilitate key recovery and fund transfers on the Bittensor network. The script enables users to derive Ed25519 keys from raw private scalars and execute transactions seamlessly.

```
$ cd scripts/bittensor-recovery-script
$ npm install && npm start
```

#### Key Features
- **Ed25519 Key Recovery**:  
  Derives public keys and constructs 64-byte secret keys from raw private scalars without clamping, ensuring compatibility with MPC outputs.
- **Transaction Creation and Broadcasting**:  
  Creates, signs, and submits `transferKeepAlive` transactions to the Bittensor network.
- **Input Validation**:  
  - Private Key: Ensures a valid 32-byte Ed25519 scalar (64 hex characters).  
  - Destination Address: Validates SS58 address format.  
  - Transfer Amount: Ensures positive numeric inputs.
- **User Prompts**:  
  Guides users through the recovery and transaction process interactively.
- **Default Endpoint**:  
  Supports `wss://entrypoint-finney.opentensor.ai:443` for network connectivity.

#### Usage
1. Enter the Ed25519 private key scalar (64 hex chars).  
2. Provide the SS58 destination address and transfer amount.  
3. Optionally configure the Bittensor endpoint.  
4. The script will derive the keypair, sign, and submit the transaction.