### PR TITLE
fix: curtail long filenames in output [RANGER-1951]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,4 @@ feat: Some new fancy feature [VAULT-111]
 
 - [ ] Tests added or updated
 - [ ] Readme updated
-- [ ] Public API Documentation updates
+- [ ] Public docs & guides updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,3 @@ feat: Some new fancy feature [VAULT-111]
 - [ ] Tests added or updated
 - [ ] Readme updated
 - [ ] Public API Documentation updates
-
-### REMEMBER: Steps after deployment
-
-- [ ] When the GQL schema changes, it must be merged in the supergraph schema in Appsync: [steps to do it](https://github.com/IoFinnet/io-vault-cldsvc-gql-backend)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.13.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
+	github.com/cdfmlr/ellipsis v0.0.1 // indirect
 	github.com/charmbracelet/bubbles v0.20.0 // indirect
 	github.com/charmbracelet/bubbletea v1.1.1 // indirect
 	github.com/charmbracelet/x/ansi v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOF
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
 github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
+github.com/cdfmlr/ellipsis v0.0.1 h1:4pwrPbKPMd4mXSdJA4CSRjgEzCbXyRiFBkmgg2KclBI=
+github.com/cdfmlr/ellipsis v0.0.1/go.mod h1:hulYx9m/7Edoo2AkRzkJ/YPDlLB45BgjitI3z0sMVFI=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -27,7 +27,7 @@ func Banner() string {
 	b := "\n"
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s     io.finnet Key Recovery Tool     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
-	b += fmt.Sprintf("%s%s               v5.2.0                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
+	b += fmt.Sprintf("%s%s               v5.2.1                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += "\n"
 	return b


### PR DESCRIPTION
[RANGER-1951](https://iofinnet.atlassian.net/browse/RANGER-1951)

### Description:

Curtail the length of long filenames in tool output.

#### Demos:

##### Before

![image](https://github.com/user-attachments/assets/273b050f-f18e-44b5-a9e6-d6a471d47e73)

![image](https://github.com/user-attachments/assets/cbcb9ec7-145e-4b5a-86ff-c6e0348997d5)

##### After

![image](https://github.com/user-attachments/assets/336a236a-ea92-4994-926b-2a75ace3b957)

![image](https://github.com/user-attachments/assets/48f40d8d-0be1-4412-ba88-d8218795314f)

### Fixes

- Curtail the length of long filenames in tool output.

### Others

- Bump version to 5.2.1.

### PR status:

- [ ] Tests added or updated
- [ ] Readme updated
- [ ] Public API Documentation updates


[RANGER-1951]: https://iofinnet.atlassian.net/browse/RANGER-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ