### PR TITLE
fix: typo in insufficient shares error text [RANGER-2246]

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -27,7 +27,7 @@ func Banner() string {
 	b := "\n"
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s     io.finnet Key Recovery Tool     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
-	b += fmt.Sprintf("%s%s               v5.1.5                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
+	b += fmt.Sprintf("%s%s               v5.1.6                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += "\n"
 	return b

--- a/tool.go
+++ b/tool.go
@@ -249,7 +249,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 	vssSharesECDSA := make(vss.Shares, len(vaultAllSharesECDSA[*vaultID]))
 	vssSharesEDDSA := make(vss.Shares, len(vaultAllSharesEDDSA[*vaultID]))
 	if len(vaultAllSharesECDSA[*vaultID]) < tPlus1 {
-		welp = fmt.Errorf("⚠ not enough shares. are you are using the newest files? (need %d, have %d)",
+		welp = fmt.Errorf("⚠ not enough shares. are you using the newest files? (need %d, have %d)",
 			tPlus1, len(vaultAllSharesECDSA[*vaultID]))
 		return
 	}


### PR DESCRIPTION
[RANGER-2246](https://iofinnet.atlassian.net/browse/RANGER-2246)

### Description:

Fixes a typo in the insufficient shares error message text.

#### Demos:

![image](https://github.com/user-attachments/assets/ed389827-7ee4-4d2e-98a6-f856c99e245d)

The message has been corrected to read "not enough shares. are you using the newest files? (need ..."


[RANGER-2246]: https://iofinnet.atlassian.net/browse/RANGER-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ