### PR TITLE
fix: refine error boxes and messaging [RANGER-2246]

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -27,7 +27,7 @@ func Banner() string {
 	b := "\n"
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s     io.finnet Key Recovery Tool     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
-	b += fmt.Sprintf("%s%s               v5.1.6                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
+	b += fmt.Sprintf("%s%s               v5.1.7                %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += fmt.Sprintf("%s%s                                     %s\n", AnsiCodes["invertOn"], AnsiCodes["bold"], AnsiCodes["reset"])
 	b += "\n"
 	return b

--- a/main.go
+++ b/main.go
@@ -74,10 +74,9 @@ func main() {
 
 	_, _, _, vaultsFormInfo, err := runTool(*vaultsDataFiles, nil, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
 	if err != nil {
-		fmt.Printf("Failed to run tool: %s\n", err)
-
-		fmt.Println("Are the words you entered correct? Are you using the newest files?")
+		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()
+		fmt.Println("Are the words you entered correct? Are you using the newest files?")
 		os.Exit(1)
 	}
 
@@ -86,7 +85,7 @@ func main() {
 	if *vaultID == "" {
 		selectedVaultId, err = ui.RunVaultPickerForm(vaultsFormInfo)
 		if err != nil {
-			fmt.Printf("Failed to run form: %s\n", err)
+			fmt.Println(ui.ErrorBox(err))
 			os.Exit(1)
 		}
 	} else {
@@ -117,8 +116,9 @@ func main() {
 	address, ecSK, edSK, _, err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
+		fmt.Println()
+		fmt.Println("Are the words you entered correct? Are you using the newest files?")
 		os.Exit(1)
-		return
 	}
 	defer func() {
 		clear(ecSK)


### PR DESCRIPTION
[RANGER-2246](https://iofinnet.atlassian.net/browse/RANGER-2246)

### Description:

The following text will now be displayed after the following "error box" outputs:

> Are the words you entered correct? Are you using the newest files?

#### Demos:

##### Before

![image](https://github.com/user-attachments/assets/cfe7456a-b3b8-412b-9127-ed767cf6e748)

##### After

The following text will now be displayed after the following "error box" outputs:

> Are the words you entered correct? Are you using the newest files?


[RANGER-2246]: https://iofinnet.atlassian.net/browse/RANGER-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ