### PR TITLE
security: dont show internal file paths in HTTP responses (IFN-03-002) [BONY-455]

### DIFF
--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -6,9 +6,11 @@ package fileutils
 
 import (
 	"errors"
-	errors2 "github.com/pkg/errors"
 	"io/fs"
+	"os"
 	"path/filepath"
+
+	errors2 "github.com/pkg/errors"
 )
 
 func StripPathFromError(err error) error {

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -6,9 +6,9 @@ package fileutils
 
 import (
 	"errors"
+	errors2 "github.com/pkg/errors"
 	"io/fs"
 	"path/filepath"
-  errors2 "github.com/pkg/errors"
 )
 
 func StripPathFromError(err error) error {

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+)
+
+func StripPathFromError(err error) error {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return &fs.PathError{
+			Op:   pathErr.Op,
+			Path: filepath.Base(pathErr.Path),
+			Err:  pathErr.Err,
+		}
+	}
+	return err
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -416,7 +416,7 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 			for _, dir := range zipExtractedDirs {
 				os.RemoveAll(dir)
 			}
-			return nil, fmt.Errorf("failed to create temporary file %s: %w", filePath, err)
+			return nil, fmt.Errorf("failed to create temporary file %s: %w", fileHeader.Filename, err)
 		}
 
 		// Copy the file content
@@ -480,7 +480,7 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 					jsonFileCount++
 				} else {
 					// Skip files we don't have mnemonics for
-					fmt.Println(ui.PlainTextf("Skipping file %s - no mnemonic provided", extractedFile))
+					fmt.Println(ui.PlainTextf("Skipping file %s - no mnemonic provided", filepath.Base(extractedFile)))
 				}
 			}
 		} else {
@@ -619,7 +619,8 @@ func (s *Server) handleListZipFiles(w http.ResponseWriter, r *http.Request) {
 		outFile, err := os.Create(filePath)
 		if err != nil {
 			file.Close()
-			http.Error(w, fmt.Sprintf("Failed to create temporary file: %v", err), http.StatusInternalServerError)
+			log.Printf("Failed to create temporary file %s: %v", filePath, err)
+			http.Error(w, "Failed to create temporary file", http.StatusInternalServerError)
 			return
 		}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -416,6 +416,7 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 			for _, dir := range zipExtractedDirs {
 				os.RemoveAll(dir)
 			}
+			log.Printf("⚠ failed to create temporary file %s: %v", filePath, err)
 			return nil, fmt.Errorf("failed to create temporary file %s: %w", fileHeader.Filename, err)
 		}
 
@@ -480,6 +481,7 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 					jsonFileCount++
 				} else {
 					// Skip files we don't have mnemonics for
+					log.Printf("⚠ skipping file %s - no mnemonic provided", extractedFile)
 					fmt.Println(ui.PlainTextf("Skipping file %s - no mnemonic provided", filepath.Base(extractedFile)))
 				}
 			}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/bittensor"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/solana"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/wif"
@@ -417,7 +418,7 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 				os.RemoveAll(dir)
 			}
 			log.Printf("⚠ failed to create temporary file %s: %v", filePath, err)
-			return nil, fmt.Errorf("failed to create temporary file %s: %w", fileHeader.Filename, err)
+			return nil, fmt.Errorf("failed to create temporary file %s: %w", filepath.Base(fileHeader.Filename), fileutils.StripPathFromError(err))
 		}
 
 		// Copy the file content

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -481,11 +481,3 @@ func inflateDataJSON(dataBytes []byte) ([]byte, error) {
 	// Use the actual implementation from the data package
 	return data.InflateSaveDataJSON(dataBytes)
 }
-
-// Helper function for getting the minimum of two integers
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/data"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/crypto/vss"
@@ -99,7 +100,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		content, err := os.ReadFile(file.File)
 		if err != nil {
 			log.Printf("⚠ failed to read file(%s): %s", file.File, err)
-			welp = fmt.Errorf("⚠ failed to read file(%s): %s", filepath.Base(file.File), err)
+			welp = fmt.Errorf("⚠ failed to read file (%s): %s", filepath.Base(file.File), fileutils.StripPathFromError(err))
 			return
 		}
 		if err := json.Unmarshal(content, saveData); err != nil {

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -97,6 +98,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 		content, err := os.ReadFile(file.File)
 		if err != nil {
+			log.Printf("⚠ failed to read file(%s): %s", file.File, err)
 			welp = fmt.Errorf("⚠ failed to read file(%s): %s", filepath.Base(file.File), err)
 			return
 		}

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -96,7 +97,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 		content, err := os.ReadFile(file.File)
 		if err != nil {
-			welp = fmt.Errorf("⚠ file to read from file(%s): %s", file, err)
+			welp = fmt.Errorf("⚠ failed to read file(%s): %s", filepath.Base(file.File), err)
 			return
 		}
 		if err := json.Unmarshal(content, saveData); err != nil {

--- a/internal/ziputils/ziputils.go
+++ b/internal/ziputils/ziputils.go
@@ -25,7 +25,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 	// Open the ZIP file
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return nil, errors2.Errorf("unable to open ZIP file `%s`: %s", zipPath, err)
+		return nil, errors2.Errorf("unable to open ZIP file `%s`: %s", filepath.Base(zipPath), err)
 	}
 	defer reader.Close()
 
@@ -62,13 +62,13 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 	// Reject ZIPs with nested directories
 	if hasNestedDirs {
 		os.RemoveAll(tempDir)
-		return nil, errors2.Errorf("ZIP file `%s` contains nested directories - only flat hierarchy of JSON files is supported", zipPath)
+		return nil, errors2.Errorf("ZIP file `%s` contains nested directories - only flat hierarchy of JSON files is supported", filepath.Base(zipPath))
 	}
 
 	// Reject ZIPs containing non-JSON files
 	if hasNonJsonFiles {
 		os.RemoveAll(tempDir)
-		return nil, errors2.Errorf("ZIP file `%s` contains non-JSON files - only JSON files are supported", zipPath)
+		return nil, errors2.Errorf("ZIP file `%s` contains non-JSON files - only JSON files are supported", filepath.Base(zipPath))
 	}
 
 	// Second pass: Extract JSON files (we've already validated that all files are JSON)
@@ -91,7 +91,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 		if err != nil {
 			rc.Close()
 			os.RemoveAll(tempDir)
-			return nil, errors2.Errorf("unable to create extracted file `%s`: %s", extractPath, err)
+			return nil, errors2.Errorf("unable to create extracted file `%s`: %s", filepath.Base(extractPath), err)
 		}
 
 		// Copy file contents
@@ -107,7 +107,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 		content, err := os.ReadFile(extractPath)
 		if err != nil {
 			os.RemoveAll(tempDir)
-			return nil, errors2.Errorf("unable to read extracted file `%s`: %s", extractPath, err)
+			return nil, errors2.Errorf("unable to read extracted file `%s`: %s", filepath.Base(extractPath), err)
 		}
 		if len(content) == 0 || content[0] != '{' {
 			os.RemoveAll(tempDir)
@@ -120,7 +120,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 	// Check if we found any JSON files
 	if len(extractedFiles) == 0 {
 		os.RemoveAll(tempDir)
-		return nil, errors2.Errorf("ZIP file `%s` does not contain any JSON files", zipPath)
+		return nil, errors2.Errorf("ZIP file `%s` does not contain any JSON files", filepath.Base(zipPath))
 	}
 
 	return extractedFiles, nil

--- a/internal/ziputils/ziputils.go
+++ b/internal/ziputils/ziputils.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	errors2 "github.com/pkg/errors"
 )
 
@@ -25,7 +26,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 	// Open the ZIP file
 	reader, err := zip.OpenReader(zipPath)
 	if err != nil {
-		return nil, errors2.Errorf("unable to open ZIP file `%s`: %s", filepath.Base(zipPath), err)
+		return nil, errors2.Errorf("unable to open ZIP file `%s`: %s", filepath.Base(zipPath), fileutils.StripPathFromError(err))
 	}
 	defer reader.Close()
 


### PR DESCRIPTION
https://iofinnet.atlassian.net/browse/BONY-455

## Changes

Remove internal file paths from error messages exposed to users via HTTP responses and logs to prevent information disclosure vulnerabilities.

### Details

- **server.go**: Strip full file paths from error responses in `processFilesAndMnemonics()` and `handleListZipFiles()` by using filename only or excluding from HTTP response
- **tool.go**: Use `filepath.Base()` to show only filename in error messages instead of full path
- **ziputils.go**: Apply `filepath.Base()` consistently across all error messages to expose only filenames, not full internal paths

### Security Impact

Prevents disclosure of internal directory structures and file system layout through error messages shown to HTTP clients and in logs.

## Test Plan

- [x] Upload a valid vault ZIP via the web UI — confirm recovery completes successfully
- [x] Upload a ZIP with non-JSON files — confirm same: filename only in error
- [x] Upload an invalid/corrupt ZIP — confirm error message exposes only the filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-facing messages now show filenames (not full paths) for uploads and archive contents.
  * Temporary-file and server error responses return generic, user-friendly messages instead of exposing internal paths.
  * Warnings and skip notices display sanitized names while detailed paths and errors are retained in server logs.

* **Chores**
  * Added a utility to strip paths from error messages and improved internal logging for safer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->