### PR TITLE
security: Validate exportFile path and fix permissions (IFN-03-005)[BONY-455]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ all: build
 
 build: build-win build-mac build-linux-amd64 build-linux-arm64 build-freebsd-amd64 build-freebsd-arm64
 
+format:
+	go fmt -x ./...
+
 build-win:
 	GOOS=windows GOARCH=amd64 go build -trimpath -o ./bin/recovery-tool.exe ./
 
@@ -31,4 +34,3 @@ test:
 	go test -race ./...
 
 .PHONY: build build-win build-linux-amd64 build-linux-arm64 build-linux build-freebsd-amd64 build-freebsd-arm64 build-freebsd build-mac sandbox test
-

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -18,13 +18,13 @@ func WriteToNewFile(filename string, data []byte, perm os.FileMode) error {
 	// O_EXCL means the file must not exist already
 	// O_WRONLY means you’re opening the file as write-only
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
-    if err != nil {
-        if os.IsExist(err) {
+	if err != nil {
+		if os.IsExist(err) {
 			return errors2.Errorf("file already exists: %s", filename)
 		} else {
 			return errors2.Errorf("failed creating file: %s: %v", filename, err)
 		}
-    }
+	}
 	defer file.Close()
 	_, err = file.Write(data)
 	if err != nil {

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package fileutils
+
+import "os"
+
+// PermissionOwnerRW is the file mode granting only the owner read/write access.
+const PermissionOwnerRW os.FileMode = 0600

--- a/internal/fileutils/fileutils.go
+++ b/internal/fileutils/fileutils.go
@@ -4,7 +4,31 @@
 
 package fileutils
 
-import "os"
+import (
+	"os"
+
+	errors2 "github.com/pkg/errors"
+)
 
 // PermissionOwnerRW is the file mode granting only the owner read/write access.
 const PermissionOwnerRW os.FileMode = 0600
+
+func WriteToNewFile(filename string, data []byte, perm os.FileMode) error {
+	// O_CREATE will create a new file if one doesn’t exist already
+	// O_EXCL means the file must not exist already
+	// O_WRONLY means you’re opening the file as write-only
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+    if err != nil {
+        if os.IsExist(err) {
+			return errors2.Errorf("file already exists: %s", filename)
+		} else {
+			return errors2.Errorf("failed creating file: %s: %v", filename, err)
+		}
+    }
+	defer file.Close()
+	_, err = file.Write(data)
+	if err != nil {
+		return errors2.Errorf("failed writing to file: %s: %v", filename, err)
+	}
+	return nil
+}

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -64,7 +64,7 @@ func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
 
 	uniqueSubfolder, err := os.MkdirTemp(baseDir, "req-")
 	if err != nil {
-		log.Printf("⚠ failed to create temporary subfolder %s: %v", uniqueSubfolder, err)
+		log.Printf("⚠ failed to create temporary subfolder under %s: %v", baseDir, err)
 		return "", errors2.Errorf("failed to create temporary subfolder: %v", err)
 	}
 

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -18,34 +18,34 @@ import (
 // ValidateExportFilename validates and sanitizes an export filename.
 // It strips directory components, rejects empty/null-byte/hidden/non-JSON filenames,
 // and returns the cleaned bare filename.
-func commonValidateExportFilename(filename string) error {
+func commonValidateExportFilename(filename string) (string, error) {
 	filename = strings.TrimSpace(filename)
 	if filename == "" {
-		return errors2.New("export filename cannot be empty")
+		return "", errors2.New("export filename cannot be empty")
 	}
 	if strings.ContainsRune(filename, 0) {
-		return errors2.New("export filename contains invalid characters")
+		return "", errors2.New("export filename contains invalid characters")
 	}
 	justFileName := filepath.Base(filename)
 	if justFileName == "." || justFileName == "/" || justFileName == "" {
-		return errors2.New("export filename is invalid")
+		return "", errors2.New("export filename is invalid")
 	}
 	if strings.HasPrefix(justFileName, ".") {
-		return errors2.Errorf("export filename cannot be a hidden file: %s", justFileName)
+		return "", errors2.Errorf("export filename cannot be a hidden file: %s", justFileName)
 	}
 	if !strings.EqualFold(filepath.Ext(justFileName), ".json") {
-		return errors2.Errorf("export filename must have .json extension, got: %s", justFileName)
+		return "", errors2.Errorf("export filename must have .json extension, got: %s", justFileName)
 	}
-	return nil
+	return filename, nil
 }
 
 func ValidateExportFilenameForCli(filename string) error {
-	err := commonValidateExportFilename(filename)
+	sanitized, err := commonValidateExportFilename(filename)
 	if err != nil {
 		return errors2.Errorf("⚠ %s", err)
 	}
-	if _, err := os.Stat(filename); err == nil {
-		return errors2.Errorf("⚠ export filename already exists: %s", filename)
+	if _, err := os.Stat(sanitized); err == nil {
+		return errors2.Errorf("⚠ export filename already exists: %s", sanitized)
 	}
 	return nil
 }
@@ -53,8 +53,7 @@ func ValidateExportFilenameForCli(filename string) error {
 // ScopeExportPath validates the filename, scopes it to the given base directory under a random subfolder each time
 // Used by web mode to confine exported files to the server's temp directory.
 func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
-	sanitized := strings.TrimSpace(filename)
-	err := commonValidateExportFilename(sanitized)
+	sanitized, err := commonValidateExportFilename(filename)
 	if err != nil {
 		return "", err
 	}

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -14,6 +14,44 @@ import (
 	errors2 "github.com/pkg/errors"
 )
 
+// ValidateExportFilename validates and sanitizes an export filename.
+// It strips directory components, rejects empty/null-byte/hidden/non-JSON filenames,
+// and returns the cleaned bare filename.
+func ValidateExportFilename(filename string) (string, error) {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return "", errors2.New("export filename cannot be empty")
+	}
+	if strings.ContainsRune(filename, 0) {
+		return "", errors2.New("export filename contains invalid characters")
+	}
+	cleaned := filepath.Base(filename)
+	if cleaned == "." || cleaned == "/" || cleaned == "" {
+		return "", errors2.New("export filename is invalid")
+	}
+	if strings.HasPrefix(cleaned, ".") {
+		return "", errors2.Errorf("export filename cannot be a hidden file: %s", cleaned)
+	}
+	if !strings.EqualFold(filepath.Ext(cleaned), ".json") {
+		return "", errors2.Errorf("export filename must have .json extension, got: %s", cleaned)
+	}
+	return cleaned, nil
+}
+
+// ScopeExportPath validates the filename and scopes it to the given base directory.
+// Used by web mode to confine exported files to the server's temp directory.
+func ScopeExportPath(filename string, baseDir string) (string, error) {
+	cleaned, err := ValidateExportFilename(filename)
+	if err != nil {
+		return "", err
+	}
+	fullPath := filepath.Join(baseDir, cleaned)
+	if filepath.Dir(fullPath) != filepath.Clean(baseDir) {
+		return "", errors2.New("export path escapes base directory")
+	}
+	return fullPath, nil
+}
+
 // The WORDS constant is defined in ui.go (24)
 
 func (v VaultsDataFile) ValidateMnemonics() error {

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -5,6 +5,7 @@
 package ui
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +50,7 @@ func ValidateExportFilenameForCli(filename string) error {
 	return nil
 }
 
-// ScopeExportPath validates the filename, scopes it to the given base directory, and checks if it already exists.
+// ScopeExportPath validates the filename, scopes it to the given base directory under a random subfolder each time
 // Used by web mode to confine exported files to the server's temp directory.
 func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
 	sanitized := strings.TrimSpace(filename)
@@ -61,12 +62,18 @@ func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
 	if sanitized != justFileName {
 		return "", errors2.Errorf("export filename cannot include directory components: %s", filename)
 	}
-	fullPath := filepath.Join(baseDir, justFileName)
-	if filepath.Dir(fullPath) != filepath.Clean(baseDir) {
-		return "", errors2.New("export path escapes base directory")
+
+	uniqueSubfolder, err := os.MkdirTemp(baseDir, "req-")
+	if err != nil {
+		log.Printf("⚠ failed to create temporary subfolder %s: %v", uniqueSubfolder, err)
+		return "", errors2.Errorf("failed to create temporary subfolder: %v", err)
 	}
+
+	fullPath := filepath.Join(uniqueSubfolder, justFileName)
 	if _, err := os.Stat(fullPath); err == nil {
-		return "", errors2.Errorf("⚠ export filename already exists: %s", fullPath)
+		// This error should not be possible to happen because the subfolder is random every time, but just in case, log it and return an error
+		log.Printf("⚠ export filename already exists in the temporary directory: %s", fullPath)
+		return "", errors2.Errorf("⚠ export filename already exists in the temporary directory: %s", filename)
 	}
 	return fullPath, nil
 }

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -17,37 +17,56 @@ import (
 // ValidateExportFilename validates and sanitizes an export filename.
 // It strips directory components, rejects empty/null-byte/hidden/non-JSON filenames,
 // and returns the cleaned bare filename.
-func ValidateExportFilename(filename string) (string, error) {
+func commonValidateExportFilename(filename string) (error) {
 	filename = strings.TrimSpace(filename)
 	if filename == "" {
-		return "", errors2.New("export filename cannot be empty")
+		return errors2.New("export filename cannot be empty")
 	}
 	if strings.ContainsRune(filename, 0) {
-		return "", errors2.New("export filename contains invalid characters")
+		return errors2.New("export filename contains invalid characters")
 	}
-	cleaned := filepath.Base(filename)
-	if cleaned == "." || cleaned == "/" || cleaned == "" {
-		return "", errors2.New("export filename is invalid")
+	justFileName := filepath.Base(filename)
+	if justFileName == "." || justFileName == "/" || justFileName == "" {
+		return errors2.New("export filename is invalid")
 	}
-	if strings.HasPrefix(cleaned, ".") {
-		return "", errors2.Errorf("export filename cannot be a hidden file: %s", cleaned)
+	if strings.HasPrefix(justFileName, ".") {
+		return errors2.Errorf("export filename cannot be a hidden file: %s", justFileName)
 	}
-	if !strings.EqualFold(filepath.Ext(cleaned), ".json") {
-		return "", errors2.Errorf("export filename must have .json extension, got: %s", cleaned)
+	if !strings.EqualFold(filepath.Ext(justFileName), ".json") {
+		return errors2.Errorf("export filename must have .json extension, got: %s", justFileName)
 	}
-	return cleaned, nil
+	return nil
 }
 
-// ScopeExportPath validates the filename and scopes it to the given base directory.
+func ValidateExportFilenameForCli(filename string) (error) {
+	err := commonValidateExportFilename(filename)
+	if err != nil {
+		return errors2.Errorf("⚠ %s", err)
+	}
+	if _, err := os.Stat(filename); err == nil {
+		return errors2.Errorf("⚠ export filename already exists: %s", filename)
+	}
+	return nil
+}
+
+// ScopeExportPath validates the filename, scopes it to the given base directory, and checks if it already exists.
 // Used by web mode to confine exported files to the server's temp directory.
-func ScopeExportPath(filename string, baseDir string) (string, error) {
-	cleaned, err := ValidateExportFilename(filename)
+func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
+	sanitized := strings.TrimSpace(filename)
+	err := ValidateExportFilenameForCli(sanitized)
 	if err != nil {
 		return "", err
 	}
-	fullPath := filepath.Join(baseDir, cleaned)
+	justFileName := filepath.Base(sanitized)
+	if sanitized != justFileName {
+		return "", errors2.Errorf("export filename cannot include directory components: %s", filename)
+	}
+	fullPath := filepath.Join(baseDir, justFileName)
 	if filepath.Dir(fullPath) != filepath.Clean(baseDir) {
 		return "", errors2.New("export path escapes base directory")
+	}
+	if _, err := os.Stat(fullPath); err == nil {
+		return "", errors2.Errorf("⚠ export filename already exists: %s", fullPath)
 	}
 	return fullPath, nil
 }

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -53,7 +53,7 @@ func ValidateExportFilenameForCli(filename string) error {
 // Used by web mode to confine exported files to the server's temp directory.
 func ScopeExportPathForWeb(filename string, baseDir string) (string, error) {
 	sanitized := strings.TrimSpace(filename)
-	err := ValidateExportFilenameForCli(sanitized)
+	err := commonValidateExportFilename(sanitized)
 	if err != nil {
 		return "", err
 	}

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -17,7 +17,7 @@ import (
 // ValidateExportFilename validates and sanitizes an export filename.
 // It strips directory components, rejects empty/null-byte/hidden/non-JSON filenames,
 // and returns the cleaned bare filename.
-func commonValidateExportFilename(filename string) (error) {
+func commonValidateExportFilename(filename string) error {
 	filename = strings.TrimSpace(filename)
 	if filename == "" {
 		return errors2.New("export filename cannot be empty")
@@ -38,7 +38,7 @@ func commonValidateExportFilename(filename string) (error) {
 	return nil
 }
 
-func ValidateExportFilenameForCli(filename string) (error) {
+func ValidateExportFilenameForCli(filename string) error {
 	err := commonValidateExportFilename(filename)
 	if err != nil {
 		return errors2.Errorf("⚠ %s", err)

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,82 @@ func TestPlainText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			plainText := PlainText(tt.input)
 			assert.Equal(t, tt.expected, plainText)
+		})
+	}
+}
+
+func TestValidateExportFilename(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{"valid simple filename", "wallet.json", "wallet.json", false},
+		{"valid with hyphens", "my-wallet.json", "my-wallet.json", false},
+		{"valid with underscores", "my_wallet.json", "my_wallet.json", false},
+		{"valid uppercase extension", "wallet.JSON", "wallet.JSON", false},
+		{"valid mixed case extension", "wallet.Json", "wallet.Json", false},
+		{"trimmed whitespace", "  wallet.json  ", "wallet.json", false},
+
+		// Path stripping — directory components removed, bare filename returned
+		{"strips directory traversal", "../../etc/passwd.json", "passwd.json", false},
+		{"strips absolute path", "/etc/wallet.json", "wallet.json", false},
+		{"strips relative path", "path/to/wallet.json", "wallet.json", false},
+		// Note: on Unix, backslash is a valid filename character, not a path separator.
+		// filepath.Base does not strip backslash-delimited components on Unix.
+		// This test verifies the actual platform behavior.
+		{"filename with backslashes on unix", "path\\to\\wallet.json", "path\\to\\wallet.json", false},
+
+		// Rejections
+		{"empty string", "", "", true},
+		{"whitespace only", "   ", "", true},
+		{"null byte", "file\x00name.json", "", true},
+		{"wrong extension txt", "wallet.txt", "", true},
+		{"wrong extension csv", "wallet.csv", "", true},
+		{"no extension", "wallet", "", true},
+		{"hidden file", ".hidden.json", "", true},
+		{"dot only", ".", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ValidateExportFilename(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestScopeExportPath(t *testing.T) {
+	baseDir := filepath.Join("/tmp", "vault-web-test")
+
+	tests := []struct {
+		name        string
+		filename    string
+		expected    string
+		expectError bool
+	}{
+		{"valid filename scoped to base", "wallet.json", filepath.Join(baseDir, "wallet.json"), false},
+		{"traversal stripped and scoped", "../../etc/passwd.json", filepath.Join(baseDir, "passwd.json"), false},
+		{"absolute path stripped and scoped", "/etc/wallet.json", filepath.Join(baseDir, "wallet.json"), false},
+		{"empty filename rejected", "", "", true},
+		{"wrong extension rejected", "wallet.txt", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ScopeExportPath(tt.filename, baseDir)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
 		})
 	}
 }

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -84,24 +84,32 @@ func TestValidateExportFilenameForCli(t *testing.T) {
 }
 
 func TestScopeExportPath(t *testing.T) {
-	baseDir := filepath.Join("/tmp", "vault-web-test")
+	baseDir := t.TempDir()
 	defer os.Remove(baseDir)
 
 	//File to test that it is not overwritten
 	dummyFile := filepath.Join(baseDir, "dummy.json")
-	os.WriteFile(dummyFile, []byte("dummy"), 0644)
+	if err := os.WriteFile(dummyFile, []byte("dummy"), 0644); err != nil {
+		t.Fatalf("failed to create dummy file: %v", err)
+	}
 
 	//File that is a soft link to the dummy file
 	softLinkFile := filepath.Join(baseDir, "soft-link.json")
-	os.Symlink(dummyFile, softLinkFile)
+	if err := os.Symlink(dummyFile, softLinkFile); err != nil {
+		t.Skipf("symlink setup not available on this platform. Skipping test: %v", err)
+	}
 
 	// Link to a non-existing file
 	softLinkToNonExistingFile := filepath.Join(baseDir, "soft-link-to-non-existing.json")
-	os.Symlink(filepath.Join(baseDir, "non-existing"), softLinkToNonExistingFile)
+	if err := os.Symlink(filepath.Join(baseDir, "non-existing"), softLinkToNonExistingFile); err != nil {
+		t.Skipf("symlink setup not available on this platform. Skipping test: %v", err)
+	}
 
 	// Directory with .json extension
 	jsonDisguisedDirectory := filepath.Join(baseDir, "directory.json")
-	os.Mkdir(jsonDisguisedDirectory, 0755)
+	if err := os.Mkdir(jsonDisguisedDirectory, 0700); err != nil {
+		t.Fatalf("failed to create json-named directory: %v", err)
+	}
 
 	tests := []struct {
 		name        string

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -51,12 +51,12 @@ func TestValidateExportFilenameForCli(t *testing.T) {
 		input       string
 		expectError bool
 	}{
-		{"valid simple filename", "wallet.json",  false},
+		{"valid simple filename", "wallet.json", false},
 		{"valid with hyphens", "my-wallet.json", false},
-		{"valid with underscores", "my_wallet.json",  false},
-		{"valid uppercase extension", "wallet.JSON",  false},
-		{"valid mixed case extension", "wallet.Json",  false},
-		{"trimmed whitespace", "  wallet.json  ",  false},
+		{"valid with underscores", "my_wallet.json", false},
+		{"valid uppercase extension", "wallet.JSON", false},
+		{"valid mixed case extension", "wallet.Json", false},
+		{"trimmed whitespace", "  wallet.json  ", false},
 
 		// Note: on Unix, backslash is a valid filename character, not a path separator.
 		{"filename with backslashes on unix", "path\\to\\wallet.json", false},

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -88,27 +88,9 @@ func TestScopeExportPath(t *testing.T) {
 	defer os.Remove(baseDir)
 
 	//File to test that it is not overwritten
-	dummyFile := filepath.Join(baseDir, "dummy.json")
-	if err := os.WriteFile(dummyFile, []byte("dummy"), 0644); err != nil {
+	dummyFile := "dummy.json"
+	if err := os.WriteFile(filepath.Join(baseDir, dummyFile), []byte("dummy"), 0644); err != nil {
 		t.Fatalf("failed to create dummy file: %v", err)
-	}
-
-	//File that is a soft link to the dummy file
-	softLinkFile := filepath.Join(baseDir, "soft-link.json")
-	if err := os.Symlink(dummyFile, softLinkFile); err != nil {
-		t.Skipf("symlink setup not available on this platform. Skipping test: %v", err)
-	}
-
-	// Link to a non-existing file
-	softLinkToNonExistingFile := filepath.Join(baseDir, "soft-link-to-non-existing.json")
-	if err := os.Symlink(filepath.Join(baseDir, "non-existing"), softLinkToNonExistingFile); err != nil {
-		t.Skipf("symlink setup not available on this platform. Skipping test: %v", err)
-	}
-
-	// Directory with .json extension
-	jsonDisguisedDirectory := filepath.Join(baseDir, "directory.json")
-	if err := os.Mkdir(jsonDisguisedDirectory, 0700); err != nil {
-		t.Fatalf("failed to create json-named directory: %v", err)
 	}
 
 	tests := []struct {
@@ -118,14 +100,14 @@ func TestScopeExportPath(t *testing.T) {
 		expectError bool
 	}{
 
-		{"valid simple filename scoped to base", "wallet.json", filepath.Join(baseDir, "wallet.json"), false},
-		{"valid with hyphens scoped to base", "my-wallet.json", filepath.Join(baseDir, "my-wallet.json"), false},
-		{"valid with underscores scoped to base", "my_wallet.json", filepath.Join(baseDir, "my_wallet.json"), false},
-		{"valid uppercase extension scoped to base", "wallet.JSON", filepath.Join(baseDir, "wallet.JSON"), false},
-		{"valid mixed case extension scoped to base", "wallet.Json", filepath.Join(baseDir, "wallet.Json"), false},
-		{"trimmed whitespace scoped to base", "  wallet.json  ", filepath.Join(baseDir, "wallet.json"), false},
+		{"valid simple filename scoped to base", "wallet.json", "wallet.json", false},
+		{"valid with hyphens scoped to base", "my-wallet.json", "my-wallet.json", false},
+		{"valid with underscores scoped to base", "my_wallet.json", "my_wallet.json", false},
+		{"valid uppercase extension scoped to base", "wallet.JSON", "wallet.JSON", false},
+		{"valid mixed case extension scoped to base", "wallet.Json", "wallet.Json", false},
+		{"trimmed whitespace scoped to base", "  wallet.json  ", "wallet.json", false},
 		// Note: on Unix, backslash is a valid filename character, not a path separator.
-		{"filename with backslashes on unix scoped to base", "path\\to\\wallet.json", filepath.Join(baseDir, "path\\to\\wallet.json"), false},
+		{"filename with backslashes on unix scoped to base", "path\\to\\wallet.json", "path\\to\\wallet.json", false},
 
 		// Rejections
 		{"empty string", "", "", true},
@@ -140,10 +122,7 @@ func TestScopeExportPath(t *testing.T) {
 		{"base tmp directory is rejected", baseDir, "", true},
 
 		// Detection of existing file
-		{"directory disguised as file is rejected", jsonDisguisedDirectory, "", true},
-		{"file already exists rejected", dummyFile, "", true},
-		{"file soft link to existing file rejected", softLinkFile, "", true},
-		{"file soft link to non-existing file rejected", softLinkToNonExistingFile, "", true},
+		{"file already exported cause no conflict", dummyFile, dummyFile, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -153,7 +132,13 @@ func TestScopeExportPath(t *testing.T) {
 				assert.Empty(t, result)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				assert.Equal(t, tt.expected, filepath.Base(result))
+
+				randomDirPath := filepath.Dir(result);
+				assert.Regexp(t, `^req-\d{2,16}$`, filepath.Base(randomDirPath))
+
+				baseTmpDirPath := filepath.Dir(randomDirPath);
+				assert.Equal(t, baseDir, baseTmpDirPath)
 			}
 		})
 	}

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,28 +45,79 @@ func TestPlainText(t *testing.T) {
 	}
 }
 
-func TestValidateExportFilename(t *testing.T) {
+func TestValidateExportFilenameForCli(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
+		expectError bool
+	}{
+		{"valid simple filename", "wallet.json",  false},
+		{"valid with hyphens", "my-wallet.json", false},
+		{"valid with underscores", "my_wallet.json",  false},
+		{"valid uppercase extension", "wallet.JSON",  false},
+		{"valid mixed case extension", "wallet.Json",  false},
+		{"trimmed whitespace", "  wallet.json  ",  false},
+
+		// Note: on Unix, backslash is a valid filename character, not a path separator.
+		{"filename with backslashes on unix", "path\\to\\wallet.json", false},
+
+		// Rejections
+		{"empty string", "", true},
+		{"whitespace only", "   ", true},
+		{"null byte", "file\x00name.json", true},
+		{"wrong extension txt", "wallet.txt", true},
+		{"wrong extension csv", "wallet.csv", true},
+		{"no extension", "wallet", true},
+		{"hidden file", ".hidden.json", true},
+		{"dot only", ".", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExportFilenameForCli(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestScopeExportPath(t *testing.T) {
+	baseDir := filepath.Join("/tmp", "vault-web-test")
+	defer os.Remove(baseDir)
+
+	//File to test that it is not overwritten
+	dummyFile := filepath.Join(baseDir, "dummy.json")
+	os.WriteFile(dummyFile, []byte("dummy"), 0644)
+
+	//File that is a soft link to the dummy file
+	softLinkFile := filepath.Join(baseDir, "soft-link.json")
+	os.Symlink(dummyFile, softLinkFile)
+
+	// Link to a non-existing file
+	softLinkToNonExistingFile := filepath.Join(baseDir, "soft-link-to-non-existing.json")
+	os.Symlink(filepath.Join(baseDir, "non-existing"), softLinkToNonExistingFile)
+
+	// Directory with .json extension
+	jsonDisguisedDirectory := filepath.Join(baseDir, "directory.json")
+	os.Mkdir(jsonDisguisedDirectory, 0755)
+
+	tests := []struct {
+		name        string
+		filename    string
 		expected    string
 		expectError bool
 	}{
-		{"valid simple filename", "wallet.json", "wallet.json", false},
-		{"valid with hyphens", "my-wallet.json", "my-wallet.json", false},
-		{"valid with underscores", "my_wallet.json", "my_wallet.json", false},
-		{"valid uppercase extension", "wallet.JSON", "wallet.JSON", false},
-		{"valid mixed case extension", "wallet.Json", "wallet.Json", false},
-		{"trimmed whitespace", "  wallet.json  ", "wallet.json", false},
 
-		// Path stripping — directory components removed, bare filename returned
-		{"strips directory traversal", "../../etc/passwd.json", "passwd.json", false},
-		{"strips absolute path", "/etc/wallet.json", "wallet.json", false},
-		{"strips relative path", "path/to/wallet.json", "wallet.json", false},
+		{"valid simple filename scoped to base", "wallet.json", filepath.Join(baseDir, "wallet.json"), false},
+		{"valid with hyphens scoped to base", "my-wallet.json", filepath.Join(baseDir, "my-wallet.json"), false},
+		{"valid with underscores scoped to base", "my_wallet.json", filepath.Join(baseDir, "my_wallet.json"), false},
+		{"valid uppercase extension scoped to base", "wallet.JSON", filepath.Join(baseDir, "wallet.JSON"), false},
+		{"valid mixed case extension scoped to base", "wallet.Json", filepath.Join(baseDir, "wallet.Json"), false},
+		{"trimmed whitespace scoped to base", "  wallet.json  ", filepath.Join(baseDir, "wallet.json"), false},
 		// Note: on Unix, backslash is a valid filename character, not a path separator.
-		// filepath.Base does not strip backslash-delimited components on Unix.
-		// This test verifies the actual platform behavior.
-		{"filename with backslashes on unix", "path\\to\\wallet.json", "path\\to\\wallet.json", false},
+		{"filename with backslashes on unix scoped to base", "path\\to\\wallet.json", filepath.Join(baseDir, "path\\to\\wallet.json"), false},
 
 		// Rejections
 		{"empty string", "", "", true},
@@ -76,39 +128,18 @@ func TestValidateExportFilename(t *testing.T) {
 		{"no extension", "wallet", "", true},
 		{"hidden file", ".hidden.json", "", true},
 		{"dot only", ".", "", true},
+		{"file with directory components rejected", "../../etc/passwd.json", "", true},
+		{"base tmp directory is rejected", baseDir, "", true},
+
+		// Detection of existing file
+		{"directory disguised as file is rejected", jsonDisguisedDirectory, "", true},
+		{"file already exists rejected", dummyFile, "", true},
+		{"file soft link to existing file rejected", softLinkFile, "", true},
+		{"file soft link to non-existing file rejected", softLinkToNonExistingFile, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ValidateExportFilename(tt.input)
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Empty(t, result)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestScopeExportPath(t *testing.T) {
-	baseDir := filepath.Join("/tmp", "vault-web-test")
-
-	tests := []struct {
-		name        string
-		filename    string
-		expected    string
-		expectError bool
-	}{
-		{"valid filename scoped to base", "wallet.json", filepath.Join(baseDir, "wallet.json"), false},
-		{"traversal stripped and scoped", "../../etc/passwd.json", filepath.Join(baseDir, "passwd.json"), false},
-		{"absolute path stripped and scoped", "/etc/wallet.json", filepath.Join(baseDir, "wallet.json"), false},
-		{"empty filename rejected", "", "", true},
-		{"wrong extension rejected", "wallet.txt", "", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := ScopeExportPath(tt.filename, baseDir)
+			result, err := ScopeExportPathForWeb(tt.filename, baseDir)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Empty(t, result)

--- a/internal/ui/ui_validate_test.go
+++ b/internal/ui/ui_validate_test.go
@@ -134,10 +134,10 @@ func TestScopeExportPath(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, filepath.Base(result))
 
-				randomDirPath := filepath.Dir(result);
+				randomDirPath := filepath.Dir(result)
 				assert.Regexp(t, `^req-\d{2,16}$`, filepath.Base(randomDirPath))
 
-				baseTmpDirPath := filepath.Dir(randomDirPath);
+				baseTmpDirPath := filepath.Dir(randomDirPath)
 				assert.Equal(t, baseDir, baseTmpDirPath)
 			}
 		})

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -214,14 +214,6 @@ func (s *Server) Stop() error {
 	return nil
 }
 
-func (s *Server) CreateExportDirectory() (string, error) {
-	exportDir, err := os.MkdirTemp(s.exportDir, "")
-	if err != nil {
-		return "", fmt.Errorf("failed to create export directory: %w", err)
-	}
-	return exportDir, nil
-}
-
 // handleListVaults handles the request to list vaults from uploaded files
 func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	// Parse the multipart form data

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -35,6 +35,7 @@ var staticFiles embed.FS
 
 const (
 	tempDirPrefix = "vault-recovery-web-"
+	exportDirPrefix = "vault-recovery-web-export-"
 )
 
 // ServerConfig holds the configuration for the http server
@@ -62,6 +63,7 @@ type RecoveryResult struct {
 type Server struct {
 	config           ServerConfig
 	tempDir          string
+	exportDir        string
 	server           *http.Server
 	listener         net.Listener
 	zipExtractedDirs []string // Tracks temporary directories created for ZIP extractions
@@ -75,9 +77,15 @@ func NewServer(config ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 
+	exportDir, err := os.MkdirTemp("", exportDirPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create export directory: %w", err)
+	}
+
 	return &Server{
 		config:           config,
 		tempDir:          tempDir,
+		exportDir:        exportDir,
 		zipExtractedDirs: make([]string, 0),
 	}, nil
 }
@@ -205,6 +213,14 @@ func (s *Server) Stop() error {
 	return nil
 }
 
+func (s *Server) CreateExportDirectory() (string, error) {
+	exportDir, err := os.MkdirTemp(s.exportDir, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to create export directory: %w", err)
+	}
+	return exportDir, nil
+}
+
 // handleListVaults handles the request to list vaults from uploaded files
 func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	// Parse the multipart form data
@@ -291,7 +307,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 	}
 	var exportFile *string
 	if exportKSFile != "" {
-		scopedPath, err := ui.ScopeExportPathForWeb(exportKSFile, s.tempDir)
+		scopedPath, err := ui.ScopeExportPathForWeb(exportKSFile, s.exportDir)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid export filename: %v", err), http.StatusBadRequest)
 			return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -55,6 +55,7 @@ type RecoveryResult struct {
 	XRPLAddress      string `json:"xrplAddress,omitempty"`
 	BittensorAddress string `json:"bittensorAddress,omitempty"`
 	SolanaAddress    string `json:"solanaAddress,omitempty"`
+	ExportedKsFile   string `json:"exportedKsFile,omitempty"`
 }
 
 // Server represents the http server for the disaster recovery tool
@@ -227,7 +228,7 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run the tool to get vault information
-	_, _, _, vaultsFormInfo, err := runTool(vaultsDataFiles, nil, nil, nil, nil, nil)
+	_, _, _, vaultsFormInfo, _, err := runTool(vaultsDataFiles, nil, nil, nil, nil, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to retrieve vault information: %v", err), http.StatusInternalServerError)
 		return
@@ -290,7 +291,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 	}
 	var exportFile *string
 	if exportKSFile != "" {
-		scopedPath, err := ui.ScopeExportPath(exportKSFile, s.tempDir)
+		scopedPath, err := ui.ScopeExportPathForWeb(exportKSFile, s.tempDir)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid export filename: %v", err), http.StatusBadRequest)
 			return
@@ -307,7 +308,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 
 	// Run the recovery tool
 	result := RecoveryResult{}
-	address, ecSK, edSK, _, err := runTool(vaultsDataFiles, &vaultID, nonceOverride, quorumOverride, exportFile, password)
+	address, ecSK, edSK, _, exportedKsFile, err := runTool(vaultsDataFiles, &vaultID, nonceOverride, quorumOverride, exportFile, password)
 
 	if err != nil {
 		result.Success = false
@@ -366,6 +367,11 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 			clear(edSK)
 		} else {
 			log.Printf("No EdDSA private key present for vault `%s`", vaultID)
+		}
+
+		if exportedKsFile != nil {
+			result.ExportedKsFile = *exportedKsFile
+			log.Printf("Wallet v3 file exported to: %s", ui.PlainText(*exportedKsFile))
 		}
 
 		// Clear sensitive data again to be safe

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -290,7 +290,12 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 	}
 	var exportFile *string
 	if exportKSFile != "" {
-		exportFile = &exportKSFile
+		scopedPath, err := ui.ScopeExportPath(exportKSFile, s.tempDir)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid export filename: %v", err), http.StatusBadRequest)
+			return
+		}
+		exportFile = &scopedPath
 	}
 
 	// Process files and mnemonics

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -63,6 +63,7 @@ type RecoveryResult struct {
 type Server struct {
 	config           ServerConfig
 	tempDir          string
+	// exportDir is never cleaned up on server shutdown, because it stores files the users can download and use later.
 	exportDir        string
 	server           *http.Server
 	listener         net.Listener

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -78,15 +78,15 @@ func NewServer(config ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 
-	exportDir, err := os.MkdirTemp("", exportDirPrefix)
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create export directory: %w", err)
+		return nil, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 
 	return &Server{
 		config:           config,
 		tempDir:          tempDir,
-		exportDir:        exportDir,
+		exportDir:        workingDir,
 		zipExtractedDirs: make([]string, 0),
 	}, nil
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -34,7 +34,7 @@ import (
 var staticFiles embed.FS
 
 const (
-	tempDirPrefix = "vault-recovery-web-"
+	tempDirPrefix   = "vault-recovery-web-"
 	exportDirPrefix = "vault-recovery-web-export-"
 )
 
@@ -61,8 +61,8 @@ type RecoveryResult struct {
 
 // Server represents the http server for the disaster recovery tool
 type Server struct {
-	config           ServerConfig
-	tempDir          string
+	config  ServerConfig
+	tempDir string
 	// exportDir is never cleaned up on server shutdown, because it stores files the users can download and use later.
 	exportDir        string
 	server           *http.Server

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/data"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/crypto/vss"
@@ -375,7 +376,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 			return
 		}
 
-		if welp = os.WriteFile(*exportKSFile, keyfile, os.ModePerm); welp != nil {
+		if welp = os.WriteFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); welp != nil {
 			return
 		}
 		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s.\n", *exportKSFile))

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -80,7 +80,7 @@ type (
 
 // Implementation of runTool for the web package
 func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string) (
-	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, welp error) {
+	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, exportedKsFile *string, welp error) {
 
 	justListingVaults := vaultID == nil || *vaultID == ""
 
@@ -259,7 +259,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 	// Just list the ID's and names?
 	if justListingVaults {
-		return "", nil, nil, orderedVaults, nil
+		return "", nil, nil, orderedVaults, nil, nil
 	}
 
 	if _, ok := vaultAllSharesECDSA[*vaultID]; !ok {
@@ -376,12 +376,14 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 			return
 		}
 
-		if welp = os.WriteFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); welp != nil {
+		if welp = fileutils.WriteToNewFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); welp != nil {
+			welp = fmt.Errorf("⚠ could not write the wallet v3 file: %v", welp)
 			return
 		}
+		exportedKsFile = exportKSFile
 		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s.\n", *exportKSFile))
 	}
-	return address, ecdsaSK, eddsaSK, orderedVaults, nil
+	return address, ecdsaSK, eddsaSK, orderedVaults, exportedKsFile, nil
 }
 
 // inflateSharesForCurve inflates shares for a specific curve

--- a/main.go
+++ b/main.go
@@ -208,7 +208,7 @@ func main() {
 		lipgloss.NewStyle().Bold(true).Render(ui.PlainTextf("RECOVERING VAULT \"%s\" WITH ID %s\n", selectedVault.Name, selectedVault.VaultID)),
 	)
 
-	address, ecSK, edSK, _, exportedKsFile,err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
+	address, ecSK, edSK, _, exportedKsFile, err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()

--- a/main.go
+++ b/main.go
@@ -111,8 +111,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Validate the exportKSFile is valid and does not already exist
-	if exportKSFile != nil && len(*exportKSFile) > 0 {
+	// Validate the exportKSFile is valid and does not already exist, only when the password is provided.
+	// Because -export defaults to wallet.json, avoiding running this block on normal recoveries to avoid errors when wallet.json already exists,
+	// even if no -password was supplied (so no export would happen).
+	if exportKSFile != nil && len(*exportKSFile) > 0 && passwordForKS != nil && len(*passwordForKS) > 0 {
 		err := ui.ValidateExportFilenameForCli(*exportKSFile)
 		if err != nil {
 			fmt.Print(ui.ErrorBox(err))
@@ -279,14 +281,15 @@ func main() {
 			fmt.Println("Solana Address: " + ui.Bold(solanaAddress))
 		}
 
+		if exportedKsFile != nil {
+			fmt.Println("\nWallet v3 file exported to:", ui.Bold(ui.PlainText(*exportedKsFile)))
+		}
+
 		// Add wallet import instructions
 		fmt.Println("\nWallet Import Instructions:")
 		fmt.Println("- XRPL, TAO, SOL: Start this tool with the -web flag to enter the browser UI recovery")
 	} else {
 		fmt.Println("\nNo EdDSA/Ed25519 private key found for this older vault.")
-	}
-	if exportedKsFile != nil {
-		fmt.Println(ui.PlainTextf("Wallet v3 file exported to: %s", ui.Bold(ui.PlainText(*exportedKsFile))))
 	}
 	fmt.Printf("\nNote: Some wallet apps may require you to prefix hex strings with 0x to load the key.\n")
 

--- a/main.go
+++ b/main.go
@@ -111,14 +111,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Validate and sanitize the export filename
+	// Validate the exportKSFile is valid and does not already exist
 	if exportKSFile != nil && len(*exportKSFile) > 0 {
-		cleanedName, err := ui.ValidateExportFilename(*exportKSFile)
+		err := ui.ValidateExportFilenameForCli(*exportKSFile)
 		if err != nil {
 			fmt.Print(ui.ErrorBox(err))
 			os.Exit(1)
 		}
-		exportKSFile = &cleanedName
 	}
 
 	/**
@@ -159,7 +158,7 @@ func main() {
 	 * Retrieve vaults information and select a vault
 	 */
 
-	_, _, _, vaultsFormInfo, err := runTool(*vaultsDataFiles, nil, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
+	_, _, _, vaultsFormInfo, _, err := runTool(*vaultsDataFiles, nil, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()
@@ -209,7 +208,7 @@ func main() {
 		lipgloss.NewStyle().Bold(true).Render(ui.PlainTextf("RECOVERING VAULT \"%s\" WITH ID %s\n", selectedVault.Name, selectedVault.VaultID)),
 	)
 
-	address, ecSK, edSK, _, err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
+	address, ecSK, edSK, _, exportedKsFile,err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()
@@ -285,6 +284,9 @@ func main() {
 		fmt.Println("- XRPL, TAO, SOL: Start this tool with the -web flag to enter the browser UI recovery")
 	} else {
 		fmt.Println("\nNo EdDSA/Ed25519 private key found for this older vault.")
+	}
+	if exportedKsFile != nil {
+		fmt.Println(ui.PlainTextf("Wallet v3 file exported to: %s", ui.Bold(ui.PlainText(*exportedKsFile))))
 	}
 	fmt.Printf("\nNote: Some wallet apps may require you to prefix hex strings with 0x to load the key.\n")
 

--- a/main.go
+++ b/main.go
@@ -111,6 +111,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Validate and sanitize the export filename
+	if exportKSFile != nil && len(*exportKSFile) > 0 {
+		cleanedName, err := ui.ValidateExportFilename(*exportKSFile)
+		if err != nil {
+			fmt.Print(ui.ErrorBox(err))
+			os.Exit(1)
+		}
+		exportKSFile = &cleanedName
+	}
+
 	/**
 	 * Run the steps to get the menmonics
 	 */

--- a/tool.go
+++ b/tool.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/data"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/crypto/vss"
@@ -344,7 +345,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 			return
 		}
 
-		if welp = os.WriteFile(*exportKSFile, keyfile, os.ModePerm); welp != nil {
+		if welp = os.WriteFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); welp != nil {
 			return
 		}
 		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s.\n", *exportKSFile))

--- a/tool.go
+++ b/tool.go
@@ -37,7 +37,7 @@ import (
 )
 
 func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string) (
-	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, welp error) {
+	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, exportedKsFile *string, welp error) {
 
 	if nonceOverride != nil && *nonceOverride > -1 {
 		fmt.Printf("\n⚠ Using reshare nonce override: %d. Be sure to set the threshold of the vault at this reshare point with -threshold, or recovery will produce incorrect data.\n", *nonceOverride)
@@ -226,7 +226,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 	// Just list the ID's and names?
 	if justListingVaults {
-		return "", nil, nil, orderedVaults, nil
+		return "", nil, nil, orderedVaults, nil, nil
 	}
 
 	println()
@@ -341,16 +341,17 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		}
 		keyfile, err2 := keystore.EncryptKey(key, *passwordForKS, keystore.StandardScryptN, keystore.StandardScryptP)
 		if err2 != nil {
-			welp = fmt.Errorf("⚠ could not create the wallet v3 file json: %v", err2)
+			welp = fmt.Errorf("⚠ could not create the wallet v3 file json %s: %v", *exportKSFile, err2)
 			return
 		}
-
-		if welp = os.WriteFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); welp != nil {
+		if err := fileutils.WriteToNewFile(*exportKSFile, keyfile, fileutils.PermissionOwnerRW); err != nil {
+			welp = fmt.Errorf("⚠ could not write the wallet v3 file %s: %v", *exportKSFile, err)
 			return
 		}
-		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s.\n", *exportKSFile))
+		exportedKsFile = exportKSFile
+		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s\n", *exportKSFile))
 	}
-	return address, ecdsaSK, eddsaSK, orderedVaults, nil
+	return address, ecdsaSK, eddsaSK, orderedVaults, exportedKsFile, nil
 }
 
 func inflateSharesForCurve[T SaveData](shares []string, justListingVaults bool) ([]*T, error) {

--- a/tool_test.go
+++ b/tool_test.go
@@ -43,7 +43,7 @@ func TestTool_New_V2_List(t *testing.T) {
 	}
 
 	// use the correct file path for tests
-	address, ecSK, edSK, vaultFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -89,7 +89,7 @@ func TestTool_New_V2_Export_lqns(t *testing.T) {
 		{File: "./test-files/new_u44.json", Mnemonics: mmNewU44},
 	}
 
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -117,7 +117,7 @@ func TestTool_NewSingle_V2_List(t *testing.T) {
 		{File: "./test-files/new_single.json", Mnemonics: mmNewSingle},
 	}
 	// use the correct file path for tests
-	address, _, edSK, vaultFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, _, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -141,7 +141,7 @@ func TestTool_NewSingle_V2_List_BadMnemonic(t *testing.T) {
 		{File: "./test-files/new_single.json", Mnemonics: mmV2},
 	}
 	// use the correct file path for tests
-	_, _, _, _, err := runTool(files, nil, nil, nil, nil, nil)
+	_, _, _, _, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -154,7 +154,7 @@ func TestTool_NewSingle_V2_Export_qvl5(t *testing.T) {
 	files := []ui.VaultsDataFile{
 		{File: "./test-files/new_single.json", Mnemonics: mmNewSingle},
 	}
-	_, ecSK, edSK, vaultsFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	_, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -181,7 +181,7 @@ func TestTool_NewSingle_V2_Export_qvl5_BadMnemonic(t *testing.T) {
 	files := []ui.VaultsDataFile{
 		{File: "./test-files/new_single.json", Mnemonics: mmV2},
 	}
-	_, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -193,7 +193,7 @@ func TestTool_Legacy_V2_List(t *testing.T) {
 	}
 
 	// use the correct file path for tests
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -219,7 +219,7 @@ func TestTool_Legacy_V2_Export_c20x(t *testing.T) {
 		{File: "./test-files/v2.json", Mnemonics: mmV2},
 	}
 
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -249,7 +249,7 @@ func TestTool_Legacy_V1_IL_List(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -279,7 +279,7 @@ func TestTool_Legacy_V1_IL_Export_m0k(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 
 	if !assert.NoError(t, err) {
 		return
@@ -312,7 +312,7 @@ func TestTool_Legacy_V1_ILM_List(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -343,7 +343,7 @@ func TestTool_Legacy_V1_ILM_Export_m0k(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 
 	if !assert.NoError(t, err) {
 		return
@@ -404,7 +404,7 @@ func TestZipFileProcessing_V2_List(t *testing.T) {
 	}
 
 	// Run the tool to list vaults - this is what we're comparing to
-	address, ecSK, edSK, expectedVaultFormData, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, expectedVaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// The test has passed if we got to this point - the ZIP file handler worked
@@ -474,7 +474,7 @@ func TestZipFileProcessing_V2_Export_lqns(t *testing.T) {
 	}
 
 	// Run the tool with regular files first to get expected result
-	expectedAddress, expectedEcSK, expectedEdSK, expectedVaultsFormData, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	expectedAddress, expectedEcSK, expectedEdSK, expectedVaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, expectedVaultsFormData, 1)
 


### PR DESCRIPTION
https://iofinnet.atlassian.net/browse/BONY-455

## Summary
- Validate export filename to prevent directory traversal and arbitrary file writes
- Store exported files in a random directory different than temp files meant to be deleted
- Restrict web mode exports to the server's temp directory via `ScopeExportPath`
- Fix exported keystore file permissions from `0777` to `0600` (owner read/write only)

## Test plan
- [x] CLI: run with `-export ../../test.json` — should export to that path
- [x] CLI: run with `-export wallet.txt` — should reject (non-.json extension)
- [x] CLI: run with `-export .hidden.json` — should reject (hidden file)
- [x] CLI: run with `-export existing.file.json` — should reject (file already exists)
- [x] CLI: with -export values '/', '.', '../' - should reject (is a folder)
- [x] Web: submit export with `wallet.json` — should write to temp dir with `0600` permissions
- [x] Web: submit export with `wallet.json` again — should fail because file exists already
- [x] Web: submit export with `../../etc/passwd.json` — should return 400 and not write outside temp dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keystore export: CLI and web flows validate export filenames, reject invalid/traversal names, scope web exports into isolated temp directories, enforce owner-only file permissions for exported files, and surface the exported keystore path on success.

* **Chores**
  * Added a repository-level code-formatting make target.

* **Tests**
  * Expanded tests to cover export filename validation and scoping behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->