### PR TITLE
security: Add cross-origin domain protections (IFN-03-006)[BONY-455]

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -63,6 +63,7 @@ type Server struct {
 	tempDir          string
 	server           *http.Server
 	listener         net.Listener
+	actualPort       int      // the port the server actually bound to
 	zipExtractedDirs []string // Tracks temporary directories created for ZIP extractions
 }
 
@@ -161,10 +162,15 @@ func (s *Server) Start() (string, error) {
 		}
 	}
 	s.listener = listener
+	s.actualPort = port
+
+	// Apply security middleware: origin validation wraps the mux,
+	// then security headers wrap everything.
+	handler := securityHeaders(validateOrigin(mux, port))
 
 	// Create the server
 	s.server = &http.Server{
-		Handler:      mux,
+		Handler:      handler,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
@@ -546,6 +552,62 @@ func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile,
 	// Store the list of extracted directories in the server for later cleanup
 	s.zipExtractedDirs = append(s.zipExtractedDirs, zipExtractedDirs...)
 	return vaultsDataFiles, nil
+}
+
+// securityHeaders wraps an http.Handler to add security headers to every response.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prevent the site from being loaded in an iframe. Removes clickjacking risks.
+		w.Header().Set("X-Frame-Options", "DENY")
+		// Prevent MIME type sniffing. Helps stop attacks where files might be served as the wrong content-type.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		// Restrict what resources this page can load and from where (only self for api, images and scripts. also inlined html styles).
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'")
+		// Only send referrer info for same-origin or top-level navigation. Limits leaking info to other sites.
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		// Forbid browser features like camera, microphone, geolocation on this site unless explicitly allowed.
+		// Protects user privacy.
+		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// validateOrigin wraps an http.Handler to reject cross-origin POST and OPTIONS requests.
+// Requests with no Origin header are allowed, because they are treated as same-origin or non-browser (e.g., curl), which are safe.
+func validateOrigin(next http.Handler, port int) http.Handler {
+	// The server always binds to localhost, so only allow requests from localhost or 127.0.0.1.
+	// Making it configurable would risk weakening security through misconfiguration
+	allowedOrigins := map[string]bool{
+		fmt.Sprintf("http://localhost:%d", port): true,
+		fmt.Sprintf("http://127.0.0.1:%d", port): true,
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Methods that modify state (POST, PUT, DELETE, PATCH) are vulnerable to CSRF attacks.
+		// Methods that don't modify state (GET, HEAD) are not vulnerable. Altough, OPTIONS is a special case.
+		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodDelete || r.Method == http.MethodPatch {
+			origin := r.Header.Get("Origin")
+			if origin != "" && !allowedOrigins[origin] {
+				http.Error(w, "Forbidden: invalid origin", http.StatusForbidden)
+				return
+			}
+		}
+
+		// empty origin indicates a non-browser or non-CORS preflight request,
+		// which should not be allowed because browsers use OPTIONS with Origin during CORS preflight. Allowing it could let cross-origin preflight requests to bypass origin checks.
+		if r.Method == http.MethodOptions {
+			origin := r.Header.Get("Origin")
+			if origin == "" || !allowedOrigins[origin] {
+				http.Error(w, "Forbidden: invalid origin", http.StatusForbidden)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // OpenBrowser opens the URL in the default browser

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -602,7 +602,7 @@ func validateOrigin(next http.Handler, port int) http.Handler {
 				http.Error(w, "Forbidden: invalid origin", http.StatusForbidden)
 				return
 			}
-			w.WriteHeader(http.StatusOK)
+			next.ServeHTTP(w, r)
 			return
 		}
 

--- a/internal/web/server_security_test.go
+++ b/internal/web/server_security_test.go
@@ -1,0 +1,169 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// dummyHandler returns a simple 200 OK handler for testing middleware.
+func dummyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	handler := securityHeaders(dummyHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t,
+		"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+		rec.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rec.Header().Get("Referrer-Policy"))
+	assert.Equal(t, "camera=(), microphone=(), geolocation=()", rec.Header().Get("Permissions-Policy"))
+}
+
+func TestValidateOrigin_AllowedOrigins(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		origin string
+	}{
+		{"POST with localhost origin", http.MethodPost, "/api/recover", "http://localhost:8080"},
+		{"POST with 127.0.0.1 origin", http.MethodPost, "/api/recover", "http://127.0.0.1:8080"},
+		{"POST with no origin header", http.MethodPost, "/api/recover", ""},
+		{"POST list-vaults with localhost", http.MethodPost, "/api/list-vaults", "http://localhost:8080"},
+		{"GET with no origin", http.MethodGet, "/", ""},
+		{"GET with malicious origin (allowed for GET)", http.MethodGet, "/static/styles.css", "http://evil.com"},
+	}
+
+	handler := validateOrigin(dummyHandler(), 8080)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code, "expected request to be allowed")
+		})
+	}
+}
+
+func TestValidateOrigin_RejectedOrigins(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		origin string
+	}{
+		{"POST from evil.com", http.MethodPost, "/api/recover", "http://evil.com"},
+		{"POST from wrong port", http.MethodPost, "/api/recover", "http://localhost:9999"},
+		{"POST from https (wrong scheme)", http.MethodPost, "/api/recover", "https://localhost:8080"},
+		{"POST from subdomain trick", http.MethodPost, "/api/recover", "http://localhost:8080.evil.com"},
+		{"POST list-vaults from evil origin", http.MethodPost, "/api/list-vaults", "http://attacker.example.com"},
+		{"POST list-zip-files from evil origin", http.MethodPost, "/api/list-zip-files", "http://evil.com:8080"},
+	}
+
+	handler := validateOrigin(dummyHandler(), 8080)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Origin", tt.origin)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code, "expected request to be rejected")
+		})
+	}
+}
+
+func TestValidateOrigin_OptionsHandling(t *testing.T) {
+	handler := validateOrigin(dummyHandler(), 8080)
+
+	t.Run("OPTIONS from evil origin rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/recover", nil)
+		req.Header.Set("Origin", "http://evil.com")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("OPTIONS with no origin rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/recover", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("OPTIONS from localhost allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/recover", nil)
+		req.Header.Set("Origin", "http://localhost:8080")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestValidateOrigin_DifferentPorts(t *testing.T) {
+	handler := validateOrigin(dummyHandler(), 8083)
+
+	t.Run("correct port accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/recover", nil)
+		req.Header.Set("Origin", "http://localhost:8083")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("wrong port rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/recover", nil)
+		req.Header.Set("Origin", "http://localhost:8080")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+}
+
+func TestSecurityHeadersOnErrorResponses(t *testing.T) {
+	// Compose both middlewares: security headers wrapping origin validation.
+	// A rejected origin should still have security headers in the response.
+	handler := securityHeaders(validateOrigin(dummyHandler(), 8080))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/recover", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	assert.NotEmpty(t, rec.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rec.Header().Get("Referrer-Policy"))
+	assert.Equal(t, "camera=(), microphone=(), geolocation=()", rec.Header().Get("Permissions-Policy"))
+}


### PR DESCRIPTION
https://iofinnet.atlassian.net/browse/BONY-455

## Summary
- Add security headers middleware (`X-Frame-Options: DENY`, `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`) applied to all HTTP responses
- Add origin validation middleware that rejects cross-origin `POST`/`PUT`/`DELETE`/`PATCH`/`OPTIONS` requests from non-localhost origins

## Manual test plan (TESTED)

1. **Security headers present:** Verify all responses include `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy`, `Referrer-Policy`, and `Permissions-Policy` headers
2. **Normal usage works:** Upload vault backup files and mnemonics through the UI, complete a full recovery flow — confirm it works as before
3. **Cross-origin POST blocked:** Open a different site (e.g. `example.com`) in the same browser, open DevTools console, run:
   ```js
   fetch('http://localhost:8080/api/list-vaults', {method: 'POST'}).then(r => console.log(r.status))
   ```
   Verify the request is blocked with 403
4. **Same-origin POST allowed:** From the app's own page (`http://localhost:8080`), run the same fetch in the console — verify it succeeds

[BONY-455]: https://iofinnet.atlassian.net/browse/BONY-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened HTTP server protection by implementing additional security response headers that mitigate framing attacks, content-type sniffing, and other common web vulnerabilities
  * Introduced origin validation to prevent unauthorised cross-origin requests and CSRF attacks on sensitive state-changing operations, whilst permitting legitimate read-only access from the browser

* **Tests**
  * Added comprehensive test coverage for the new security header and origin validation mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->