### PR TITLE
security: zeroization on vaultsDataFiles holding mnemonic (IFN-03-008)[BONY-455,BONY-919]

### DIFF
--- a/internal/ui/ui_input.go
+++ b/internal/ui/ui_input.go
@@ -23,6 +23,8 @@ type (
 		Mnemonics string
 	}
 
+	VaultsDataFiles []VaultsDataFile
+
 	// MnemonicsFormModel is a struct that represents the model for the mnemonics entry.
 	MnemonicsFormModel struct {
 		filenames    []string
@@ -30,6 +32,19 @@ type (
 		extractedAll bool
 	}
 )
+
+// removes reference to mnemonic strings from the entry.
+func (file *VaultsDataFile) Zeroize() {
+	file.Mnemonics = ""
+	file.File = ""
+}
+
+// removes reference to mnemonic strings from all the entries.
+func (files *VaultsDataFiles) Zeroize() {
+	for i := range *files {
+		(*files)[i].Zeroize()
+	}
+}
 
 func NewMnemonicsForm(config config.AppConfig) MnemonicsFormModel {
 	return MnemonicsFormModel{
@@ -39,8 +54,8 @@ func NewMnemonicsForm(config config.AppConfig) MnemonicsFormModel {
 	}
 }
 
-func (m *MnemonicsFormModel) Run() (*[]VaultsDataFile, error) {
-	filesWithMnemonics := make([]VaultsDataFile, 0, len(m.filenames))
+func (m *MnemonicsFormModel) Run() (*VaultsDataFiles, error) {
+	filesWithMnemonics := make(VaultsDataFiles, 0, len(m.filenames))
 
 	// Make a first pass to calculate the total number of files
 	totalJSONFiles := 0

--- a/internal/ui/ui_input_test.go
+++ b/internal/ui/ui_input_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVaultsDataFilesZeroize(t *testing.T) {
+	files := VaultsDataFiles{
+		{File: "test1.json", Mnemonics: "word1 word2 word3"},
+		{File: "test2.json", Mnemonics: "word4 word5 word6"},
+	}
+
+	files.Zeroize()
+
+	for _, f := range files {
+		assert.Equal(t, "", f.Mnemonics)
+	}
+}
+
+func TestVaultsDataFilesZeroize_EmptySlice(t *testing.T) {
+	files := VaultsDataFiles{}
+	files.Zeroize() // should not panic
+}
+
+func TestVaultsDataFilesZeroize_EmptyMnemonics(t *testing.T) {
+	files := VaultsDataFiles{
+		{File: "test.json", Mnemonics: ""},
+	}
+	files.Zeroize() // should not panic
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -219,6 +219,7 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to process files: %v", err), http.StatusBadRequest)
 		return
 	}
+	defer vaultsDataFiles.Zeroize()
 
 	// If no vault data files were processed, return an error
 	if len(vaultsDataFiles) == 0 {
@@ -299,6 +300,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to process files: %v", err), http.StatusBadRequest)
 		return
 	}
+	defer vaultsDataFiles.Zeroize()
 
 	// Run the recovery tool
 	result := RecoveryResult{}
@@ -377,7 +379,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 }
 
 // processFilesAndMnemonics processes the uploaded files and their mnemonics
-func (s *Server) processFilesAndMnemonics(r *http.Request) ([]ui.VaultsDataFile, error) {
+func (s *Server) processFilesAndMnemonics(r *http.Request) (ui.VaultsDataFiles, error) {
 	// Debug logging to help diagnose form issues
 	// Get file uploads - the frontend might use "files" or file input specific IDs
 	var fileHeaders []*multipart.FileHeader

--- a/main.go
+++ b/main.go
@@ -145,6 +145,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	defer vaultsDataFiles.Zeroize()
+
 	/**
 	 * Retrieve vaults information and select a vault
 	 */


### PR DESCRIPTION
https://iofinnet.atlassian.net/browse/BONY-455
https://iofinnet.atlassian.net/browse/BONY-919

Fix:
- Zeroization of mnemonics in VaultsDataFile struct by setting its field (of type string) to empty string.

### **Notes about why not using []byte and clear() instead** 

The `mnemonic` string is provided by the `huh` library or by HTTP multipart request as strings, so they are already in memory, and strings can't be cleared because they are immutable.
The current file.Mnemonics = "" approach is a reasonable best-effort — it drops the reference and allows the GC to eventually reclaim the memory, even if it doesn't guarantee immediate overwriting. The language makes no guarantees about when memory will be reclaimed or overwritten, and strings may persist in memory far longer than necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Enhanced secure handling of sensitive mnemonic data by implementing automatic memory clearing when data is no longer needed, reducing exposure to potential data leaks.

* **Tests**
  * Added unit tests to verify secure data clearing functionality works correctly across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->