### PR TITLE
feat: VS disaster recovery - BONY-1344

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,23 +98,30 @@ Unblock-File -Path "recovery-tool.exe"
 
 ## Usage
 
-Run the recovery tool with your backup JSON files or ZIP archives containing JSON files.
+Run the recovery tool with your backup JSON files, .dr files or ZIP archives containing JSON files or .dr files.
 ``` bash
 ./recovery-tool-mac sandbox/file1.json sandbox/file2.json
 ```
 
-You can also use ZIP archives that contain multiple JSON files:
+.dr files are files created by Virtual Signers. When referencing .dr files with the recovery tool, provide the path to the private key used by the Virtual Signer for Disaster Recovery files. This is the private part of the public/private ML-KEM-768 key pair
+created as the initial step of the Disaster Recovery process. See scripts/posix/gen_mlkem768.sh in this project for a sample script that calls `openssl` to generate the ML-KEM-768 key pair.
+
+``` bash
+./recovery-tool-mac -private-key sandbox/mlkem768_priv.pem sandbox/file1.json sandbox/019f2838-e9ab-7e0c-8a45-cf8a3ae18e8e.ecdsa.secp256k1.dr sandbox/019f2838-e9ab-7e0c-8a45-cf8a3ae18e8e.eddsa.ed25519.dr
+```
+
+You can also use ZIP archives that contain multiple JSON/dr files:
 ```bash
 ./recovery-tool-mac sandbox/backup.zip
 ```
 
 > [!NOTE]
-> When using ZIP files, ensure they contain only a flat hierarchy of JSON files with no nested directories.
-> Each ZIP file will be treated as a batch of JSON files, all using the same mnemonic phrase.
+> When using ZIP files, ensure they contain only a flat hierarchy of JSON or .dr files with no nested directories.
+> Each ZIP file will be treated as a batch of JSON or .dr files. All JSON must use the same mnemonic phrase and the .dr files must belong to the same vault.
 
 You can also provide the vault ID you want to recover, which will skip the step of choosing a vault:
 ```bash
-./recovery-tool-mac -vault-id cl347wz8w00006sx3f1g23p4s sandbox/file1.json sandbox/file2.json
+./recovery-tool-mac -vault-id "019f2838-e9ab-7e0c-8a45-cf89a63d9169"  -private-key sandbox/mlkem768_priv.pem sandbox/file1.json sandbox/019f2838-e9ab-7e0c-8a45-cf8a3ae18e8e.ecdsa.secp256k1.dr sandbox/019f2838-e9ab-7e0c-8a45-cf8a3ae18e8e.eddsa.ed25519.dr
 ```
 
 Use multiple ZIP archives:
@@ -122,7 +129,7 @@ Use multiple ZIP archives:
 ./recovery-tool-mac sandbox/backups1.zip sandbox/backups2.zip sandbox/backups3.zip
 ```
 
-Note: You cannot mix JSON and ZIP files in the same command.
+Note: You cannot mix JSON and ZIP files, or .dr and ZIP files in the same command.
 
 Replace `mac` with one of the following depending on your computer's OS and architecture:
 - `linux-amd64` - For Linux on x86-64 processors

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type AppConfig struct {
 	QuorumOverride   int
 	ExportKSFile     string
 	PasswordForKS    string
+	PrivateKeyFile   string   // Path to the ML-KEM-768 private key PEM used to decrypt Virtual Signer .dr files
 	ZipExtractedDirs []string // Tracks temporary directories created for ZIP extraction
 }
 

--- a/internal/dr/convert.go
+++ b/internal/dr/convert.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import (
+	"fmt"
+
+	"github.com/binance-chain/tss-lib/crypto"
+	ecdsa_keygen "github.com/binance-chain/tss-lib/ecdsa/keygen"
+	eddsa_keygen "github.com/binance-chain/tss-lib/eddsa/keygen"
+)
+
+// ToECDSASaveData converts decrypted .dr ECDSA shares into the legacy tss-lib LocalPartySaveData
+// type this CLI's existing Shamir/Feldman VSS reconstruction path already operates on.
+func (s *ECDSASharesAndVaultId) ToECDSASaveData() ([]*ecdsa_keygen.LocalPartySaveData, error) {
+	out := make([]*ecdsa_keygen.LocalPartySaveData, 0, len(s.Data))
+	for _, share := range s.Data {
+		pub, err := share.ECDSAPub.toCryptoECPoint()
+		if err != nil {
+			return nil, fmt.Errorf("vault %s: %w", s.VaultId, err)
+		}
+		out = append(out, &ecdsa_keygen.LocalPartySaveData{
+			LocalSecrets: ecdsa_keygen.LocalSecrets{Xi: share.Xi, ShareID: share.ShareID},
+			ECDSAPub:     pub,
+		})
+	}
+	return out, nil
+}
+
+// ToEdDSASaveData converts decrypted .dr EdDSA shares into the legacy tss-lib LocalPartySaveData
+// type this CLI's existing Shamir/Feldman VSS reconstruction path already operates on.
+func (s *EdDSASharesAndVaultId) ToEdDSASaveData() ([]*eddsa_keygen.LocalPartySaveData, error) {
+	out := make([]*eddsa_keygen.LocalPartySaveData, 0, len(s.Data))
+	for _, share := range s.Data {
+		pub, err := share.EDDSAPub.toCryptoECPoint()
+		if err != nil {
+			return nil, fmt.Errorf("vault %s: %w", s.VaultId, err)
+		}
+		out = append(out, &eddsa_keygen.LocalPartySaveData{
+			LocalSecrets: eddsa_keygen.LocalSecrets{Xi: share.Xi, ShareID: share.ShareID},
+			EDDSAPub:     pub,
+		})
+	}
+	return out, nil
+}
+
+func (p *ECPoint) toCryptoECPoint() (*crypto.ECPoint, error) {
+	if p == nil {
+		return nil, fmt.Errorf("missing public key in .dr share")
+	}
+	curve, err := ResolveCurve(p.Curve)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.NewECPoint(curve, p.Coords[0], p.Coords[1])
+}

--- a/internal/dr/curve.go
+++ b/internal/dr/curve.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import (
+	"crypto/elliptic"
+	"fmt"
+
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+// ResolveCurve maps a tss-lib/v4 curve name (from a decrypted ECPoint's "Curve" field) to the
+// matching curve from the legacy tss-lib fork this CLI already reconstructs with. Both libraries
+// wrap the same underlying packages (btcec secp256k1, dcrd edwards), so coordinates decoded from
+// v4's JSON plug directly into the existing vss.Shares.ReConstruct(curve) call.
+func ResolveCurve(name string) (elliptic.Curve, error) {
+	switch name {
+	case "secp256k1":
+		return tss.S256(), nil
+	case "ed25519":
+		return tss.Edwards(), nil
+	default:
+		return nil, fmt.Errorf("unsupported curve %q in .dr file", name)
+	}
+}

--- a/internal/dr/decrypt.go
+++ b/internal/dr/decrypt.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/mlkem"
+	"encoding/pem"
+	"fmt"
+)
+
+// kemCapsuleSize is the fixed size in bytes of an ML-KEM-768 ciphertext capsule (NIST standard).
+const kemCapsuleSize = 1088
+
+// DecryptFile decrypts a Virtual Signer ".dr" file's raw bytes using the ML-KEM-768 private key PEM.
+// Wire format: [1088-byte ML-KEM ciphertext][AES-256-GCM nonce(12) + ciphertext + tag].
+func DecryptFile(pemBytes, raw []byte) ([]byte, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse private key PEM")
+	}
+	decapsulationKey, err := mlkem.NewDecapsulationKey768(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ML-KEM-768 private key: %w", err)
+	}
+	if len(raw) <= kemCapsuleSize {
+		return nil, fmt.Errorf("file is too small to contain a valid .dr payload")
+	}
+	cipherTextKEM, aesPayload := raw[:kemCapsuleSize], raw[kemCapsuleSize:]
+
+	sharedSecret, err := decapsulationKey.Decapsulate(cipherTextKEM)
+	if err != nil {
+		return nil, fmt.Errorf("ML-KEM decapsulation failed (wrong private key or corrupted file): %w", err)
+	}
+
+	blk, err := aes.NewCipher(sharedSecret)
+	if err != nil {
+		return nil, err
+	}
+	aesGCM, err := cipher.NewGCM(blk)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := aesGCM.NonceSize()
+	if len(aesPayload) < nonceSize {
+		return nil, fmt.Errorf(".dr AES payload is too short")
+	}
+	nonce, ciphertext := aesPayload[:nonceSize], aesPayload[nonceSize:]
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("AES-GCM decryption failed (wrong private key or corrupted file): %w", err)
+	}
+	return plaintext, nil
+}

--- a/internal/dr/decrypt.go
+++ b/internal/dr/decrypt.go
@@ -8,12 +8,52 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/mlkem"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 )
 
 // kemCapsuleSize is the fixed size in bytes of an ML-KEM-768 ciphertext capsule (NIST standard).
 const kemCapsuleSize = 1088
+
+// mlkem768SeedLen is the length in bytes of a raw ML-KEM-768 private key seed (FIPS 203).
+const mlkem768SeedLen = 64
+
+// oidMLKEM768 is the ML-KEM-768 algorithm identifier (RFC 9935 / NIST CSOR
+// 2.16.840.1.101.3.4.4.2). OpenSSL 3.5+'s `genpkey -algorithm ML-KEM-768`
+// (and RFC 9935-compliant tooling generally) wraps the raw 64-byte seed in a
+// standard PKCS#8 PrivateKeyInfo DER structure using this OID.
+var oidMLKEM768 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 4, 2}
+
+type mlkemAlgorithmIdentifier struct {
+	Algorithm asn1.ObjectIdentifier
+}
+
+type mlkemPKCS8PrivateKeyInfo struct {
+	Version    int
+	Algo       mlkemAlgorithmIdentifier
+	PrivateKey []byte
+}
+
+// parseMLKEM768PrivateKeyPKCS8 unwraps a standard PKCS#8 PrivateKeyInfo DER
+// structure (RFC 9935) to recover the raw 64-byte ML-KEM-768 seed.
+func parseMLKEM768PrivateKeyPKCS8(der []byte) ([]byte, error) {
+	var info mlkemPKCS8PrivateKeyInfo
+	rest, err := asn1.Unmarshal(der, &info)
+	if err != nil {
+		return nil, fmt.Errorf("parsing PKCS#8 structure: %w", err)
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("trailing data after PKCS#8 structure")
+	}
+	if !info.Algo.Algorithm.Equal(oidMLKEM768) {
+		return nil, fmt.Errorf("unexpected algorithm OID %v, expected ML-KEM-768 (%v)", info.Algo.Algorithm, oidMLKEM768)
+	}
+	if len(info.PrivateKey) != mlkem768SeedLen {
+		return nil, fmt.Errorf("unexpected private key length %d, expected a %d-byte seed", len(info.PrivateKey), mlkem768SeedLen)
+	}
+	return info.PrivateKey, nil
+}
 
 // DecryptFile decrypts a Virtual Signer ".dr" file's raw bytes using the ML-KEM-768 private key PEM.
 // Wire format: [1088-byte ML-KEM ciphertext][AES-256-GCM nonce(12) + ciphertext + tag].
@@ -22,7 +62,11 @@ func DecryptFile(pemBytes, raw []byte) ([]byte, error) {
 	if block == nil {
 		return nil, fmt.Errorf("failed to parse private key PEM")
 	}
-	decapsulationKey, err := mlkem.NewDecapsulationKey768(block.Bytes)
+	seed, err := parseMLKEM768PrivateKeyPKCS8(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ML-KEM-768 private key PEM: %w", err)
+	}
+	decapsulationKey, err := mlkem.NewDecapsulationKey768(seed)
 	if err != nil {
 		return nil, fmt.Errorf("invalid ML-KEM-768 private key: %w", err)
 	}

--- a/internal/dr/decrypt_test.go
+++ b/internal/dr/decrypt_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/mlkem"
+	"crypto/rand"
+	"encoding/pem"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func encryptForTest(t *testing.T, pub *mlkem.EncapsulationKey768, plaintext []byte) []byte {
+	t.Helper()
+	sharedSecret, cipherTextKEM := pub.Encapsulate()
+
+	blk, err := aes.NewCipher(sharedSecret)
+	require.NoError(t, err)
+	aesGCM, err := cipher.NewGCM(blk)
+	require.NoError(t, err)
+	nonce := make([]byte, aesGCM.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonce)
+	require.NoError(t, err)
+	sealed := aesGCM.Seal(nonce, nonce, plaintext, nil)
+
+	return append(cipherTextKEM, sealed...)
+}
+
+func TestDecryptFile_RoundTrip(t *testing.T) {
+	priv, err := mlkem.GenerateKey768()
+	require.NoError(t, err)
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv.Bytes()})
+
+	want := []byte(`{"Data":[{"Xi":1,"ShareID":2}],"VaultId":"vault-1","Threshold":2}`)
+	raw := encryptForTest(t, priv.EncapsulationKey(), want)
+
+	got, err := DecryptFile(privPEM, raw)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestDecryptFile_WrongKey(t *testing.T) {
+	priv1, err := mlkem.GenerateKey768()
+	require.NoError(t, err)
+	priv2, err := mlkem.GenerateKey768()
+	require.NoError(t, err)
+	priv2PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv2.Bytes()})
+
+	raw := encryptForTest(t, priv1.EncapsulationKey(), []byte("secret"))
+
+	_, err = DecryptFile(priv2PEM, raw)
+	require.Error(t, err)
+}

--- a/internal/dr/decrypt_test.go
+++ b/internal/dr/decrypt_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/cipher"
 	"crypto/mlkem"
 	"crypto/rand"
+	"encoding/asn1"
 	"encoding/pem"
 	"io"
 	"testing"
@@ -32,10 +33,23 @@ func encryptForTest(t *testing.T, pub *mlkem.EncapsulationKey768, plaintext []by
 	return append(cipherTextKEM, sealed...)
 }
 
+// mlkemPrivateKeyPEM wraps a raw ML-KEM-768 seed in the standard PKCS#8
+// PrivateKeyInfo DER structure (RFC 9935), matching what OpenSSL 3.5+ and
+// current key-generation tooling produce.
+func mlkemPrivateKeyPEM(t *testing.T, seed []byte) []byte {
+	t.Helper()
+	der, err := asn1.Marshal(mlkemPKCS8PrivateKeyInfo{
+		Algo:       mlkemAlgorithmIdentifier{Algorithm: oidMLKEM768},
+		PrivateKey: seed,
+	})
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
 func TestDecryptFile_RoundTrip(t *testing.T) {
 	priv, err := mlkem.GenerateKey768()
 	require.NoError(t, err)
-	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv.Bytes()})
+	privPEM := mlkemPrivateKeyPEM(t, priv.Bytes())
 
 	want := []byte(`{"Data":[{"Xi":1,"ShareID":2}],"VaultId":"vault-1","Threshold":2}`)
 	raw := encryptForTest(t, priv.EncapsulationKey(), want)
@@ -50,7 +64,7 @@ func TestDecryptFile_WrongKey(t *testing.T) {
 	require.NoError(t, err)
 	priv2, err := mlkem.GenerateKey768()
 	require.NoError(t, err)
-	priv2PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv2.Bytes()})
+	priv2PEM := mlkemPrivateKeyPEM(t, priv2.Bytes())
 
 	raw := encryptForTest(t, priv1.EncapsulationKey(), []byte("secret"))
 

--- a/internal/dr/parse.go
+++ b/internal/dr/parse.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Kind int
+
+const (
+	KindUnknown Kind = iota
+	KindECDSA
+	KindEdDSA
+)
+
+// Parsed holds the outcome of decrypting and classifying one .dr file.
+type Parsed struct {
+	Kind  Kind
+	ECDSA *ECDSASharesAndVaultId
+	EdDSA *EdDSASharesAndVaultId
+}
+
+// probe sniffs which of ECDSAPub/EDDSAPub is present in the first share, without
+// committing to a concrete share type up front.
+type probe struct {
+	Data []struct {
+		ECDSAPub json.RawMessage `json:"ECDSAPub"`
+		EDDSAPub json.RawMessage `json:"EDDSAPub"`
+	} `json:"Data"`
+}
+
+// DecryptAndParse decrypts a .dr file with the given ML-KEM-768 private key PEM, then classifies
+// it as ECDSA or EdDSA by inspecting the decrypted content -- not the filename -- and unmarshals
+// it into the matching mirror type.
+func DecryptAndParse(pemBytes, raw []byte) (*Parsed, error) {
+	plaintext, err := DecryptFile(pemBytes, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var p probe
+	if err := json.Unmarshal(plaintext, &p); err != nil {
+		return nil, fmt.Errorf("invalid .dr payload format: %w", err)
+	}
+	if len(p.Data) == 0 {
+		return nil, fmt.Errorf(".dr payload contains no share data")
+	}
+
+	switch {
+	case len(p.Data[0].ECDSAPub) > 0 && len(p.Data[0].EDDSAPub) == 0:
+		var shares ECDSASharesAndVaultId
+		if err := json.Unmarshal(plaintext, &shares); err != nil {
+			return nil, fmt.Errorf("invalid ECDSA .dr payload: %w", err)
+		}
+		return &Parsed{Kind: KindECDSA, ECDSA: &shares}, nil
+	case len(p.Data[0].EDDSAPub) > 0 && len(p.Data[0].ECDSAPub) == 0:
+		var shares EdDSASharesAndVaultId
+		if err := json.Unmarshal(plaintext, &shares); err != nil {
+			return nil, fmt.Errorf("invalid EdDSA .dr payload: %w", err)
+		}
+		return &Parsed{Kind: KindEdDSA, EdDSA: &shares}, nil
+	default:
+		return nil, fmt.Errorf("could not determine algorithm (ECDSA/EdDSA) of .dr payload")
+	}
+}

--- a/internal/dr/parse.go
+++ b/internal/dr/parse.go
@@ -5,6 +5,7 @@
 package dr
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 )
@@ -17,53 +18,69 @@ const (
 	KindEdDSA
 )
 
+// FileEnvelope is the on-disk JSON structure Virtual Signer writes for a .dr file: vaultId,
+// requestId, reshareNonce, algo, and curve are plaintext so operators/tooling can identify a DR
+// file's epoch and algorithm without decrypting it; dataB64 is the opaque base64-encoded
+// ML-KEM+AES-GCM ciphertext produced by EncryptingMarshallerForDR, decrypted out-of-band during an
+// actual DR event.
+type FileEnvelope struct {
+	VaultId      string `json:"vaultId"`
+	RequestId    string `json:"requestId"`
+	ReshareNonce int64  `json:"reshareNonce"`
+	Algo         string `json:"algo"`
+	Curve        string `json:"curve"`
+	DataB64      string `json:"dataB64"`
+}
+
 // Parsed holds the outcome of decrypting and classifying one .dr file.
 type Parsed struct {
-	Kind  Kind
-	ECDSA *ECDSASharesAndVaultId
-	EdDSA *EdDSASharesAndVaultId
+	Kind     Kind
+	ECDSA    *ECDSASharesAndVaultId
+	EdDSA    *EdDSASharesAndVaultId
+	Envelope FileEnvelope
 }
 
-// probe sniffs which of ECDSAPub/EDDSAPub is present in the first share, without
-// committing to a concrete share type up front.
-type probe struct {
-	Data []struct {
-		ECDSAPub json.RawMessage `json:"ECDSAPub"`
-		EDDSAPub json.RawMessage `json:"EDDSAPub"`
-	} `json:"Data"`
-}
-
-// DecryptAndParse decrypts a .dr file with the given ML-KEM-768 private key PEM, then classifies
-// it as ECDSA or EdDSA by inspecting the decrypted content -- not the filename -- and unmarshals
-// it into the matching mirror type.
+// DecryptAndParse parses a .dr file's JSON envelope, decrypts its dataB64 ciphertext with the
+// given ML-KEM-768 private key PEM, and unmarshals the plaintext into the type matching the
+// envelope's plaintext algo field.
+//
+// The envelope's vaultId/requestId/reshareNonce/algo/curve fields are plaintext and not covered
+// by the AES-GCM authentication tag, so callers must treat them as unauthenticated metadata (fine
+// for grouping/display) and rely on the decrypted payload's own VaultId/Threshold, which is
+// authenticated, for anything security-relevant.
 func DecryptAndParse(pemBytes, raw []byte) (*Parsed, error) {
-	plaintext, err := DecryptFile(pemBytes, raw)
+	var envelope FileEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("invalid .dr file (not a JSON envelope): %w", err)
+	}
+	if envelope.DataB64 == "" {
+		return nil, fmt.Errorf("invalid .dr file: missing dataB64")
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(envelope.DataB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 in .dr file dataB64: %w", err)
+	}
+
+	plaintext, err := DecryptFile(pemBytes, ciphertext)
 	if err != nil {
 		return nil, err
 	}
 
-	var p probe
-	if err := json.Unmarshal(plaintext, &p); err != nil {
-		return nil, fmt.Errorf("invalid .dr payload format: %w", err)
-	}
-	if len(p.Data) == 0 {
-		return nil, fmt.Errorf(".dr payload contains no share data")
-	}
-
-	switch {
-	case len(p.Data[0].ECDSAPub) > 0 && len(p.Data[0].EDDSAPub) == 0:
+	switch envelope.Algo {
+	case "ECDSA":
 		var shares ECDSASharesAndVaultId
 		if err := json.Unmarshal(plaintext, &shares); err != nil {
 			return nil, fmt.Errorf("invalid ECDSA .dr payload: %w", err)
 		}
-		return &Parsed{Kind: KindECDSA, ECDSA: &shares}, nil
-	case len(p.Data[0].EDDSAPub) > 0 && len(p.Data[0].ECDSAPub) == 0:
+		return &Parsed{Kind: KindECDSA, ECDSA: &shares, Envelope: envelope}, nil
+	case "EDDSA":
 		var shares EdDSASharesAndVaultId
 		if err := json.Unmarshal(plaintext, &shares); err != nil {
 			return nil, fmt.Errorf("invalid EdDSA .dr payload: %w", err)
 		}
-		return &Parsed{Kind: KindEdDSA, EdDSA: &shares}, nil
+		return &Parsed{Kind: KindEdDSA, EdDSA: &shares, Envelope: envelope}, nil
 	default:
-		return nil, fmt.Errorf("could not determine algorithm (ECDSA/EdDSA) of .dr payload")
+		return nil, fmt.Errorf("unknown .dr algo %q", envelope.Algo)
 	}
 }

--- a/internal/dr/types.go
+++ b/internal/dr/types.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package dr
+
+import "math/big"
+
+// ECPoint mirrors tss-lib/v4's crypto.ECPoint JSON encoding: {"Curve": "...", "Coords": [X, Y]}.
+// This is a deliberate local copy, not an import of tss-lib/v4 -- see package doc in curve.go.
+type ECPoint struct {
+	Curve  string
+	Coords [2]*big.Int
+}
+
+// ECDSAShare mirrors the fields of tss-lib/v4's tss/ecdsa/keygen.LocalPartySaveData
+// needed for Shamir/Feldman VSS reconstruction.
+type ECDSAShare struct {
+	Xi, ShareID *big.Int
+	ECDSAPub    *ECPoint
+}
+
+// EdDSAShare mirrors the fields of tss-lib/v4's tss/schnorr/keygen.LocalPartySaveData
+// needed for Shamir/Feldman VSS reconstruction.
+type EdDSAShare struct {
+	Xi, ShareID *big.Int
+	EDDSAPub    *ECPoint
+}
+
+// ECDSASharesAndVaultId mirrors the Virtual Signer's common.PrivateECDSASharesAndVaultId.
+type ECDSASharesAndVaultId struct {
+	Data      []*ECDSAShare
+	VaultId   string
+	Threshold int
+}
+
+// EdDSASharesAndVaultId mirrors the Virtual Signer's common.PrivateEdDSASharesAndVaultId.
+type EdDSASharesAndVaultId struct {
+	Data      []*EdDSAShare
+	VaultId   string
+	Threshold int
+}

--- a/internal/ui/ui_input.go
+++ b/internal/ui/ui_input.go
@@ -6,6 +6,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -27,11 +28,17 @@ type (
 
 	// MnemonicsFormModel is a struct that represents the model for the mnemonics entry.
 	MnemonicsFormModel struct {
-		filenames    []string
-		totalFiles   int
-		extractedAll bool
+		filenames      []string
+		totalFiles     int
+		extractedAll   bool
+		privateKeyFile string
 	}
 )
+
+// isDRFile reports whether pathname is a Virtual Signer .dr file, identified by extension.
+func isDRFile(pathname string) bool {
+	return strings.EqualFold(filepath.Ext(pathname), ".dr")
+}
 
 // removes reference to mnemonic strings from the entry.
 func (file *VaultsDataFile) Zeroize() {
@@ -48,9 +55,10 @@ func (files *VaultsDataFiles) Zeroize() {
 
 func NewMnemonicsForm(config config.AppConfig) MnemonicsFormModel {
 	return MnemonicsFormModel{
-		filenames:    config.Filenames,
-		totalFiles:   len(config.Filenames),
-		extractedAll: false,
+		filenames:      config.Filenames,
+		totalFiles:     len(config.Filenames),
+		extractedAll:   false,
+		privateKeyFile: config.PrivateKeyFile,
 	}
 }
 
@@ -105,6 +113,12 @@ func (m *MnemonicsFormModel) Run() (*VaultsDataFiles, error) {
 			continue
 		}
 
+		// .dr files are decrypted with a shared private key, not a per-file mnemonic; skip the prompt.
+		if isDRFile(pathname) {
+			filesWithMnemonics = append(filesWithMnemonics, VaultsDataFile{File: pathname})
+			continue
+		}
+
 		// Process regular JSON files
 		displayFileName := filepath.Base(pathname)
 
@@ -150,6 +164,12 @@ func (m *MnemonicsFormModel) Run() (*VaultsDataFiles, error) {
 		fmt.Printf("Processing %d extracted JSON files from ZIP archives\n", len(extractedFiles))
 
 		for _, extractedFile := range extractedFiles {
+			// .dr files are decrypted with a shared private key, not a per-file mnemonic; skip the prompt.
+			if isDRFile(extractedFile) {
+				filesWithMnemonics = append(filesWithMnemonics, VaultsDataFile{File: extractedFile})
+				continue
+			}
+
 			// Use the full filename from the ZIP
 			fileName := filepath.Base(extractedFile)
 			displayFileName := fileName
@@ -198,7 +218,51 @@ func (m *MnemonicsFormModel) Run() (*VaultsDataFiles, error) {
 	fmt.Println(m.fileList(filesWithMnemonics))
 	fmt.Print("All mnemonics entered\n\n")
 
+	if err := m.ensurePrivateKeyFile(filesWithMnemonics); err != nil {
+		return nil, err
+	}
+
 	return &filesWithMnemonics, nil
+}
+
+// ensurePrivateKeyFile prompts once for the ML-KEM-768 private key PEM path if any .dr file is
+// present and no path was already supplied via -private-key, then records it in the global config
+// for main.go to read and load after this form returns.
+func (m *MnemonicsFormModel) ensurePrivateKeyFile(files VaultsDataFiles) error {
+	hasDRFile := false
+	for _, f := range files {
+		if isDRFile(f.File) {
+			hasDRFile = true
+			break
+		}
+	}
+	if !hasDRFile || m.privateKeyFile != "" {
+		return nil
+	}
+
+	var path string
+	input := huh.NewInput().
+		Key("privateKeyFile").
+		Title("Virtual Signer .dr files detected").
+		Description("Enter the path to the ML-KEM-768 private key PEM file").
+		Value(&path).
+		Validate(func(input string) error {
+			if strings.TrimSpace(input) == "" {
+				return errors2.New("private key path cannot be empty")
+			}
+			if _, err := os.Stat(input); err != nil {
+				return errors2.Errorf("unable to see file `%s` - does it exist?", input)
+			}
+			return nil
+		})
+	form := huh.NewForm(huh.NewGroup(input)).WithTheme(huh.ThemeBase16())
+	if err := form.Run(); err != nil {
+		return err
+	}
+
+	m.privateKeyFile = path
+	config.GlobalConfig.PrivateKeyFile = path
+	return nil
 }
 
 // processZipFileForMnemonics extracts JSON files from a ZIP archive

--- a/internal/ui/ui_validate.go
+++ b/internal/ui/ui_validate.go
@@ -168,8 +168,20 @@ func ValidateFiles(appConfig *config.AppConfig) error {
 	appConfig.Filenames = processedFiles
 	appConfig.ZipExtractedDirs = zipExtractedDirs
 
-	// Second pass: validate all files are readable and proper JSON
+	// Second pass: validate all files are readable and proper JSON.
+	// Virtual Signer .dr files are opaque encrypted binary blobs, not JSON, so they're exempt
+	// from the JSON-shape check; they're validated by attempting decryption in runTool instead.
 	for _, file := range processedFiles {
+		if strings.EqualFold(filepath.Ext(file), ".dr") {
+			if _, err := os.Stat(file); err != nil {
+				for _, dir := range zipExtractedDirs {
+					os.RemoveAll(dir)
+				}
+				return errors2.Errorf("unable to read file `%s`: %s", file, err)
+			}
+			continue
+		}
+
 		content, err := os.ReadFile(file)
 		if err != nil {
 			// Clean up extracted files before returning error

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -245,7 +245,7 @@ func (s *Server) handleListVaults(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run the tool to get vault information
-	_, _, _, vaultsFormInfo, _, err := runTool(vaultsDataFiles, nil, nil, nil, nil, nil)
+	_, _, _, vaultsFormInfo, _, err := runTool(vaultsDataFiles, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to retrieve vault information: %v", err), http.StatusInternalServerError)
 		return
@@ -326,7 +326,7 @@ func (s *Server) handleRecovery(w http.ResponseWriter, r *http.Request) {
 
 	// Run the recovery tool
 	result := RecoveryResult{}
-	address, ecSK, edSK, _, exportedKsFile, err := runTool(vaultsDataFiles, &vaultID, nonceOverride, quorumOverride, exportFile, password)
+	address, ecSK, edSK, _, exportedKsFile, err := runTool(vaultsDataFiles, &vaultID, nonceOverride, quorumOverride, exportFile, password, nil)
 
 	if err != nil {
 		result.Success = false

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/data"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/dr"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/binance-chain/tss-lib/crypto"
@@ -81,7 +82,7 @@ type (
 )
 
 // Implementation of runTool for the web package
-func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string) (
+func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string, privateKeyPEM []byte) (
 	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, exportedKsFile *string, welp error) {
 
 	justListingVaults := vaultID == nil || *vaultID == ""
@@ -95,6 +96,15 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 	// Process each vault data file
 	for _, file := range vaultsDataFile {
+		if strings.EqualFold(filepath.Ext(file.File), ".dr") {
+			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults,
+				clearVaults, vaultAllSharesECDSA, vaultAllSharesEDDSA, vaultHasEDDSA); err != nil {
+				welp = err
+				return
+			}
+			continue
+		}
+
 		saveData := new(SavedData)
 
 		content, err := os.ReadFile(file.File)
@@ -387,6 +397,83 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s.\n", *exportKSFile))
 	}
 	return address, ecdsaSK, eddsaSK, orderedVaults, exportedKsFile, nil
+}
+
+// processDRFile decrypts a Virtual Signer .dr file and folds its shares into the same per-vault
+// share pools the legacy mnemonic-encrypted path populates, so a single recovery run can mix both
+// file formats for the same vault.
+func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListingVaults bool,
+	clearVaults ClearVaultMap, vaultAllSharesECDSA VaultAllSharesECDSA, vaultAllSharesEDDSA VaultAllSharesEdDSA,
+	vaultHasEDDSA map[string]bool) error {
+
+	if len(privateKeyPEM) == 0 {
+		return fmt.Errorf("⚠ %s is a Virtual Signer .dr file; supply the ML-KEM-768 private key PEM to decrypt it", path)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("⚠ failed to read file(%s): %s", filepath.Base(path), fileutils.StripPathFromError(err))
+	}
+
+	parsed, err := dr.DecryptAndParse(privateKeyPEM, raw)
+	if err != nil {
+		return fmt.Errorf("⚠ failed to decrypt %s: %s", filepath.Base(path), err)
+	}
+
+	var vID string
+	var threshold int
+	switch parsed.Kind {
+	case dr.KindECDSA:
+		vID, threshold = parsed.ECDSA.VaultId, parsed.ECDSA.Threshold
+	case dr.KindEdDSA:
+		vID, threshold = parsed.EdDSA.VaultId, parsed.EdDSA.Threshold
+	}
+
+	// only look at the vault we're interested in, if one was supplied
+	if !justListingVaults && vID != *vaultID {
+		return nil
+	}
+
+	if err := ensureClearVaultThreshold(clearVaults, vID, threshold, path); err != nil {
+		return err
+	}
+
+	switch parsed.Kind {
+	case dr.KindECDSA:
+		shares, err := parsed.ECDSA.ToECDSASaveData()
+		if err != nil {
+			return fmt.Errorf("⚠ %s: %s", filepath.Base(path), err)
+		}
+		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], shares...)
+	case dr.KindEdDSA:
+		shares, err := parsed.EdDSA.ToEdDSASaveData()
+		if err != nil {
+			return fmt.Errorf("⚠ %s: %s", filepath.Base(path), err)
+		}
+		vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], shares...)
+		vaultHasEDDSA[vID] = true
+	}
+	return nil
+}
+
+// ensureClearVaultThreshold makes sure a ClearVault entry exists for a vault first seen via a .dr
+// file (which carries no vault Name, only a VaultId), and errors out if a .dr file's threshold
+// disagrees with a threshold already established for this vault from another input file.
+func ensureClearVaultThreshold(clearVaults ClearVaultMap, vID string, threshold int, path string) error {
+	if threshold < 1 {
+		return fmt.Errorf("⚠ %s does not carry a valid threshold", filepath.Base(path))
+	}
+	existing, ok := clearVaults[vID]
+	if !ok {
+		clearVaults[vID] = &ClearVault{Name: vID, Quroum: threshold}
+		return nil
+	}
+	if existing.Quroum != 0 && existing.Quroum != threshold {
+		return fmt.Errorf("⚠ vault %s: threshold mismatch between input files (%d vs %d). "+
+			"Make sure all supplied files are from the same vault epoch", vID, existing.Quroum, threshold)
+	}
+	existing.Quroum = threshold
+	return nil
 }
 
 // inflateSharesForCurve inflates shares for a specific curve

--- a/internal/web/tool.go
+++ b/internal/web/tool.go
@@ -78,6 +78,15 @@ type (
 	VaultAllSharesECDSA map[string][]*ecdsa_keygen.LocalPartySaveData
 	VaultAllSharesEdDSA map[string][]*eddsa_keygen.LocalPartySaveData
 
+	// drVaultShares accumulates one reshare epoch's worth of .dr shares for a vault (one .dr file
+	// per device per algorithm), pending the "pick the highest nonce" selection in runTool.
+	drVaultShares struct {
+		threshold int
+		ecdsa     []*ecdsa_keygen.LocalPartySaveData
+		eddsa     []*eddsa_keygen.LocalPartySaveData
+		hasEdDSA  bool
+	}
+
 	SaveData interface{}
 )
 
@@ -93,12 +102,16 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 	vaultAllSharesEDDSA := make(VaultAllSharesEdDSA, len(vaultsDataFile)*16)
 	vaultHasEDDSA := make(map[string]bool, len(vaultsDataFile)*16)
 	vaultLastNonces := make(map[string]int, len(vaultsDataFile)*16)
+	// .dr files carry a reshare nonce (unlike the legacy mnemonic-encrypted JSON below, one .dr
+	// file is one device's shares for one specific epoch), so they're grouped by vault+nonce here
+	// and folded in below once every input file has been seen, picking the highest nonce the same
+	// way the legacy path does.
+	drSharesByVaultNonce := make(map[string]map[int]*drVaultShares, len(vaultsDataFile))
 
 	// Process each vault data file
 	for _, file := range vaultsDataFile {
 		if strings.EqualFold(filepath.Ext(file.File), ".dr") {
-			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults,
-				clearVaults, vaultAllSharesECDSA, vaultAllSharesEDDSA, vaultHasEDDSA); err != nil {
+			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults, drSharesByVaultNonce); err != nil {
 				welp = err
 				return
 			}
@@ -133,30 +146,15 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 			}
 
 			// take the highest reshareNonce we have saved (best effort)
-			lastReshareNonce := -1
+			nonces := make(map[int]bool, len(resharesMap))
 			for nonce := range resharesMap {
-				// support the -nonce flag to override the last reshare nonce we use
-				if !justListingVaults && nonceOverride != nil && *nonceOverride > -1 && *nonceOverride != nonce {
-					continue
-				}
-				if nonce > lastReshareNonce {
-					lastReshareNonce = nonce
-				}
+				nonces[nonce] = true
 			}
+			lastReshareNonce := pickLastReshareNonce(nonces, vID, clearVaults, nonceOverride, justListingVaults, vaultLastNonces)
 			if lastReshareNonce == -1 {
 				//welp = fmt.Errorf("⚠ no share data found for vault `%s` in save file", vID)
 				continue // not a show stopper
 			}
-			if glbLastReShareNonce, ok := vaultLastNonces[vID]; ok && glbLastReShareNonce != lastReshareNonce {
-				vaultName := clearVaults[vID].Name
-				fmt.Println(ui.PlainTextf("\n⚠ Non matching reshare nonce for vault `%s`. You may have to specify prior reshare config with -nonce and -threshold when recovering that vault.", vaultName))
-				if lastReshareNonce-1 >= 0 {
-					fmt.Println(ui.PlainTextf("⚠ If you have problems recovering that vault, you could try: -vault-id %s -nonce %d -threshold x. Replace x with previous vault threshold.", vID, lastReshareNonce-1))
-				} else {
-					println()
-				}
-			}
-			vaultLastNonces[vID] = lastReshareNonce
 			cipheredVault := resharesMap[lastReshareNonce]
 
 			// DECRYPT
@@ -253,6 +251,32 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		}
 
 		clear(aesKey32)
+	}
+
+	// Fold in the .dr shares accumulated above: for each vault, pick the highest reshare nonce
+	// (or -nonce override) the same way the legacy mnemonic-encrypted JSON path does, warning on
+	// cross-file nonce disagreement, then merge that epoch's shares into the same pools used by
+	// the legacy path so a single recovery run can mix both file formats for a vault.
+	for vID, byNonce := range drSharesByVaultNonce {
+		nonces := make(map[int]bool, len(byNonce))
+		for nonce := range byNonce {
+			nonces[nonce] = true
+		}
+		lastReshareNonce := pickLastReshareNonce(nonces, vID, clearVaults, nonceOverride, justListingVaults, vaultLastNonces)
+		if lastReshareNonce == -1 {
+			continue
+		}
+		chosen := byNonce[lastReshareNonce]
+		if err := ensureClearVaultThreshold(clearVaults, vID, chosen.threshold,
+			fmt.Sprintf(".dr files for vault %s at reshare nonce %d", vID, lastReshareNonce)); err != nil {
+			welp = err
+			return
+		}
+		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], chosen.ecdsa...)
+		if chosen.hasEdDSA {
+			vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], chosen.eddsa...)
+			vaultHasEDDSA[vID] = true
+		}
 	}
 
 	// populate vault IDs
@@ -403,8 +427,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 // share pools the legacy mnemonic-encrypted path populates, so a single recovery run can mix both
 // file formats for the same vault.
 func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListingVaults bool,
-	clearVaults ClearVaultMap, vaultAllSharesECDSA VaultAllSharesECDSA, vaultAllSharesEDDSA VaultAllSharesEdDSA,
-	vaultHasEDDSA map[string]bool) error {
+	drSharesByVaultNonce map[string]map[int]*drVaultShares) error {
 
 	if len(privateKeyPEM) == 0 {
 		return fmt.Errorf("⚠ %s is a Virtual Signer .dr file; supply the ML-KEM-768 private key PEM to decrypt it", path)
@@ -420,6 +443,8 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 		return fmt.Errorf("⚠ failed to decrypt %s: %s", filepath.Base(path), err)
 	}
 
+	// The reconstructed vault ID and threshold come from the decrypted (AEAD-authenticated)
+	// payload, not the plaintext envelope fields, since the latter aren't tamper-evident.
 	var vID string
 	var threshold int
 	switch parsed.Kind {
@@ -433,9 +458,23 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 	if !justListingVaults && vID != *vaultID {
 		return nil
 	}
+	if threshold < 1 {
+		return fmt.Errorf("⚠ %s does not carry a valid threshold", filepath.Base(path))
+	}
 
-	if err := ensureClearVaultThreshold(clearVaults, vID, threshold, path); err != nil {
-		return err
+	nonce := int(parsed.Envelope.ReshareNonce)
+	byNonce, ok := drSharesByVaultNonce[vID]
+	if !ok {
+		byNonce = make(map[int]*drVaultShares)
+		drSharesByVaultNonce[vID] = byNonce
+	}
+	entry, ok := byNonce[nonce]
+	if !ok {
+		entry = &drVaultShares{threshold: threshold}
+		byNonce[nonce] = entry
+	} else if entry.threshold != threshold {
+		return fmt.Errorf("⚠ %s: threshold %d disagrees with another .dr file at the same reshare nonce %d for vault %s (%d)",
+			filepath.Base(path), threshold, nonce, vID, entry.threshold)
 	}
 
 	switch parsed.Kind {
@@ -444,16 +483,53 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 		if err != nil {
 			return fmt.Errorf("⚠ %s: %s", filepath.Base(path), err)
 		}
-		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], shares...)
+		entry.ecdsa = append(entry.ecdsa, shares...)
 	case dr.KindEdDSA:
 		shares, err := parsed.EdDSA.ToEdDSASaveData()
 		if err != nil {
 			return fmt.Errorf("⚠ %s: %s", filepath.Base(path), err)
 		}
-		vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], shares...)
-		vaultHasEDDSA[vID] = true
+		entry.eddsa = append(entry.eddsa, shares...)
+		entry.hasEdDSA = true
 	}
 	return nil
+}
+
+// pickLastReshareNonce selects the reshare nonce to use for a vault from the set of nonces found
+// across its input files (honoring the -nonce override), warning if it disagrees with the nonce
+// already picked for this vault from another input file. Shared by the legacy mnemonic-encrypted
+// JSON path and the Virtual Signer .dr JSON path so multi-epoch inputs are handled consistently
+// regardless of file format. Returns -1 if no nonce survives the override filter.
+func pickLastReshareNonce(nonces map[int]bool, vID string, clearVaults ClearVaultMap, nonceOverride *int,
+	justListingVaults bool, vaultLastNonces map[string]int) int {
+
+	lastReshareNonce := -1
+	for nonce := range nonces {
+		// support the -nonce flag to override the last reshare nonce we use
+		if !justListingVaults && nonceOverride != nil && *nonceOverride > -1 && *nonceOverride != nonce {
+			continue
+		}
+		if nonce > lastReshareNonce {
+			lastReshareNonce = nonce
+		}
+	}
+	if lastReshareNonce == -1 {
+		return -1
+	}
+	if glbLastReShareNonce, ok := vaultLastNonces[vID]; ok && glbLastReShareNonce != lastReshareNonce {
+		vaultName := vID
+		if cv, ok2 := clearVaults[vID]; ok2 && cv != nil {
+			vaultName = cv.Name
+		}
+		fmt.Println(ui.PlainTextf("\n⚠ Non matching reshare nonce for vault `%s`. You may have to specify prior reshare config with -nonce and -threshold when recovering that vault.", vaultName))
+		if lastReshareNonce-1 >= 0 {
+			fmt.Println(ui.PlainTextf("⚠ If you have problems recovering that vault, you could try: -vault-id %s -nonce %d -threshold x. Replace x with previous vault threshold.", vID, lastReshareNonce-1))
+		} else {
+			println()
+		}
+	}
+	vaultLastNonces[vID] = lastReshareNonce
+	return lastReshareNonce
 }
 
 // ensureClearVaultThreshold makes sure a ClearVault entry exists for a vault first seen via a .dr

--- a/internal/ziputils/ziputils.go
+++ b/internal/ziputils/ziputils.go
@@ -20,6 +20,12 @@ func IsZipFile(filename string) bool {
 	return strings.ToLower(filepath.Ext(filename)) == ".zip"
 }
 
+// allowedZipExtensions are the file extensions ProcessZipFile accepts inside a flat ZIP archive:
+// ".json" for legacy mnemonic-encrypted vault backups (mobile app exports), ".dr" for Virtual
+// Signer disaster-recovery share files. Both are JSON documents, so both get the same
+// first-byte-is-'{' sanity check below.
+var allowedZipExtensions = map[string]bool{".json": true, ".dr": true}
+
 // ProcessZipFile extracts JSON files from a ZIP archive to a temporary directory
 // It returns a list of extracted file paths, or an error if the ZIP isn't valid
 func ProcessZipFile(zipPath string) ([]string, error) {
@@ -54,7 +60,7 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 		}
 
 		// Check file extension
-		if strings.ToLower(filepath.Ext(f.Name)) != ".json" {
+		if !allowedZipExtensions[strings.ToLower(filepath.Ext(f.Name))] {
 			hasNonJsonFiles = true
 			break
 		}
@@ -69,10 +75,10 @@ func ProcessZipFile(zipPath string) ([]string, error) {
 	// Reject ZIPs containing non-JSON files
 	if hasNonJsonFiles {
 		os.RemoveAll(tempDir)
-		return nil, errors2.Errorf("ZIP file `%s` contains non-JSON files - only JSON files are supported", filepath.Base(zipPath))
+		return nil, errors2.Errorf("ZIP file `%s` contains non-JSON files - only .json and .dr files are supported", filepath.Base(zipPath))
 	}
 
-	// Second pass: Extract JSON files (we've already validated that all files are JSON)
+	// Second pass: Extract JSON/.dr files (we've already validated the extensions)
 	for _, f := range reader.File {
 		// Skip directories
 		if f.FileInfo().IsDir() {

--- a/internal/ziputils/ziputils_test.go
+++ b/internal/ziputils/ziputils_test.go
@@ -325,6 +325,66 @@ func createEmptyZip(zipPath string) error {
 	return zipWriter.Close()
 }
 
+// TestProcessZipFile_WithDRFile verifies that a flat ZIP mixing a Virtual Signer .dr file (JSON,
+// per the current on-disk envelope format) alongside a .json file is accepted and both are
+// extracted, since .dr is now a supported extension inside a ZIP.
+func TestProcessZipFile_WithDRFile(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "with_dr.zip")
+
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("failed to create test ZIP file: %v", err)
+	}
+	zipWriter := zip.NewWriter(zipFile)
+
+	jsonWriter, err := zipWriter.Create("share.json")
+	if err != nil {
+		t.Fatalf("failed to add json entry: %v", err)
+	}
+	if _, err := jsonWriter.Write([]byte(`{"key": "value"}`)); err != nil {
+		t.Fatalf("failed to write json entry: %v", err)
+	}
+
+	drWriter, err := zipWriter.Create("req0.ecdsa.secp256k1.dr")
+	if err != nil {
+		t.Fatalf("failed to add .dr entry: %v", err)
+	}
+	if _, err := drWriter.Write([]byte(`{"vaultId":"v1","requestId":"req0","reshareNonce":1,"algo":"ECDSA","curve":"secp256k1","dataB64":"AAAA"}`)); err != nil {
+		t.Fatalf("failed to write .dr entry: %v", err)
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("failed to close ZIP writer: %v", err)
+	}
+	if err := zipFile.Close(); err != nil {
+		t.Fatalf("failed to close ZIP file: %v", err)
+	}
+
+	extractedFiles, err := ProcessZipFile(zipPath)
+	if err != nil {
+		t.Fatalf("ProcessZipFile() unexpected error: %v", err)
+	}
+	if len(extractedFiles) > 0 {
+		defer os.RemoveAll(filepath.Dir(extractedFiles[0]))
+	}
+	if len(extractedFiles) != 2 {
+		t.Fatalf("ProcessZipFile() extracted %d files, want 2", len(extractedFiles))
+	}
+
+	var sawJSON, sawDR bool
+	for _, f := range extractedFiles {
+		switch strings.ToLower(filepath.Ext(f)) {
+		case ".json":
+			sawJSON = true
+		case ".dr":
+			sawDR = true
+		}
+	}
+	if !sawJSON || !sawDR {
+		t.Fatalf("expected both a .json and a .dr file among extracted files, got %v", extractedFiles)
+	}
+}
+
 // Helper function to check if a file exists
 func fileExists(path string) bool {
 	_, err := os.Stat(path)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 	quorumOverride := flag.Int("threshold", 0, "(Optional) Vault Quorum (Threshold) override. Try it if the tool advises you to do so.")
 	passwordForKS := flag.String("password", "", "(Optional) Encryption password for the Ethereum wallet v3 file; use with -export")
 	exportKSFile := flag.String("export", "wallet.json", "(Optional) Filename to export a Ethereum wallet v3 JSON to; use with -password.")
+	privateKeyFile := flag.String("private-key", "", "(Required when recovering from Virtual Signer .dr files) Path to the ML-KEM-768 private key PEM.")
 
 	// Note: Transaction modes have been removed - use scripts in scripts/ directory instead
 
@@ -99,6 +100,7 @@ func main() {
 		QuorumOverride:   *quorumOverride,
 		ExportKSFile:     *exportKSFile,
 		PasswordForKS:    *passwordForKS,
+		PrivateKeyFile:   *privateKeyFile,
 		ZipExtractedDirs: []string{}, // Initialize empty slice for tracking ZIP dirs
 	}
 
@@ -158,11 +160,23 @@ func main() {
 
 	defer vaultsDataFiles.Zeroize()
 
+	// Read the ML-KEM-768 private key PEM, if a path was supplied via -private-key or entered
+	// interactively above (for .dr files); config.GlobalConfig.PrivateKeyFile reflects either source.
+	var privateKeyPEM []byte
+	if config.GlobalConfig.PrivateKeyFile != "" {
+		var err2 error
+		privateKeyPEM, err2 = os.ReadFile(config.GlobalConfig.PrivateKeyFile)
+		if err2 != nil {
+			fmt.Print(ui.ErrorBox(fmt.Errorf("⚠ unable to read private key file `%s`: %s", config.GlobalConfig.PrivateKeyFile, err2)))
+			os.Exit(1)
+		}
+	}
+
 	/**
 	 * Retrieve vaults information and select a vault
 	 */
 
-	_, _, _, vaultsFormInfo, _, err := runTool(*vaultsDataFiles, nil, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
+	_, _, _, vaultsFormInfo, _, err := runTool(*vaultsDataFiles, nil, nonceOverride, quorumOverride, exportKSFile, passwordForKS, privateKeyPEM)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()
@@ -212,7 +226,7 @@ func main() {
 		lipgloss.NewStyle().Bold(true).Render(ui.PlainTextf("RECOVERING VAULT \"%s\" WITH ID %s\n", selectedVault.Name, selectedVault.VaultID)),
 	)
 
-	address, ecSK, edSK, _, exportedKsFile, err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS)
+	address, ecSK, edSK, _, exportedKsFile, err := runTool(*vaultsDataFiles, &selectedVault.VaultID, nonceOverride, quorumOverride, exportKSFile, passwordForKS, privateKeyPEM)
 	if err != nil {
 		fmt.Println(ui.ErrorBox(err))
 		fmt.Println()

--- a/scripts/posix/README.md
+++ b/scripts/posix/README.md
@@ -1,0 +1,17 @@
+# gen_mlkem768.sh script
+
+This script creates a ML-KEM-768 key pair. This key pair can be used for the Virtual Signer Disaster Recovery feature.
+
+```
+ Usage:
+   ./gen_mlkem768.sh [basename]
+
+ Produces:
+   <basename>_priv.pem   (private key, PKCS#8 PEM, RFC 9935 minimal
+                          "bare-seed" form: just the 64-byte FIPS 203
+                          seed, no OpenSSL-specific CHOICE wrapper)
+   <basename>_pub.pem    (public key, PEM, SubjectPublicKeyInfo, raw
+                           FIPS 203 "ek" bytes)
+```
+
+Add the `<basename>_pub.pem` file path to the `DRPKPEMFile` configuration.

--- a/scripts/posix/gen_mlkem768.sh
+++ b/scripts/posix/gen_mlkem768.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+#
+# gen_mlkem768.sh
+#
+# Generates a NIST FIPS 203 ML-KEM-768 key pair using OpenSSL and
+# writes them to PEM files.
+#
+# Requirements: OpenSSL 3.5.0 or later (ML-KEM support was added in
+# OpenSSL 3.5). Check with: openssl version
+#
+# Usage:
+#   ./gen_mlkem768.sh [basename]
+#
+# Produces:
+#   <basename>_priv.pem   (private key, PKCS#8 PEM, RFC 9935 minimal
+#                          "bare-seed" form: just the 64-byte FIPS 203
+#                          seed, no OpenSSL-specific CHOICE wrapper)
+#   <basename>_pub.pem    (public key, PEM, SubjectPublicKeyInfo, raw
+#                          FIPS 203 "ek" bytes)
+#
+# This "bare-seed" private key form is interoperable with other RFC
+# 9935-compliant tooling (e.g. Go's crypto/mlkem package wrapped in a
+# standard PKCS#8 structure), unlike OpenSSL's richer default formats
+# which embed extra format-selection tagging of their own.
+#
+# Default basename is "mlkem768" if not given.
+
+set -eu
+
+ALG="ML-KEM-768"
+BASENAME="${1:-mlkem768}"
+PRIV_KEY="${BASENAME}_priv.pem"
+PUB_KEY="${BASENAME}_pub.pem"
+
+# --- Sanity checks -----------------------------------------------------
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "Error: openssl not found in PATH." >&2
+    exit 1
+fi
+
+OPENSSL_VERSION_STR=$(openssl version 2>/dev/null || true)
+echo "Using: ${OPENSSL_VERSION_STR}"
+
+# Verify this build of OpenSSL actually knows about ML-KEM-768 before
+# attempting to use it, so we can give a clear error message instead of
+# an opaque OpenSSL failure.
+if ! openssl list -key-managers 2>/dev/null | grep -qi 'ML-KEM-768'; then
+    echo "Error: this OpenSSL build does not support ${ALG}." >&2
+    echo "ML-KEM support requires OpenSSL 3.5.0 or later." >&2
+    exit 1
+fi
+
+if [ -e "${PRIV_KEY}" ] || [ -e "${PUB_KEY}" ]; then
+    echo "Error: output file(s) already exist:" >&2
+    [ -e "${PRIV_KEY}" ] && echo "  ${PRIV_KEY}" >&2
+    [ -e "${PUB_KEY}" ] && echo "  ${PUB_KEY}" >&2
+    echo "Refusing to overwrite. Remove them or choose a different basename." >&2
+    exit 1
+fi
+
+# --- Key generation ------------------------------------------------------
+
+# Generate the private key (PKCS#8 PEM).
+#
+# By default, OpenSSL writes BOTH the 64-byte FIPS 203 seed and the full
+# expanded decapsulation key into the file (its "seed-priv"/"both" form),
+# which is larger and uses an OpenSSL-specific CHOICE encoding that
+# predates the finalized standard.
+#
+# We instead request the "bare-seed" output format: just the 64-byte
+# seed, stored directly as the PKCS#8 privateKey OCTET STRING with no
+# extra ASN.1 wrapping. This is the minimal form defined by RFC 9935
+# ("Internet X.509 PKI - Algorithm Identifiers for ML-KEM") and is what
+# most non-OpenSSL tooling (e.g. Go's crypto/mlkem seed export) expects.
+umask 077
+openssl genpkey -algorithm "${ALG}" \
+    -provparam ml-kem.output_formats=bare-seed \
+    -out "${PRIV_KEY}"
+
+# Derive the public key from the private key.
+openssl pkey -in "${PRIV_KEY}" -pubout -out "${PUB_KEY}"
+
+# --- Summary -------------------------------------------------------------
+
+chmod 600 "${PRIV_KEY}"
+chmod 644 "${PUB_KEY}"
+
+echo "Generated ${ALG} key pair:"
+echo "  Private key: ${PRIV_KEY} (mode 600)"
+echo "  Public key:  ${PUB_KEY} (mode 644)"
+echo
+# echo "Private key ASN.1 structure (should show a plain 64-byte OCTET"
+# echo "STRING seed, not an OpenSSL CHOICE/SEQUENCE wrapper):"
+# openssl asn1parse -in "${PRIV_KEY}"

--- a/tool.go
+++ b/tool.go
@@ -59,12 +59,16 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 	vaultAllSharesEDDSA := make(VaultAllSharesEdDSA, len(vaultsDataFile)*16)
 	vaultHasEDDSA := make(map[string]bool, len(vaultsDataFile)*16)
 	vaultLastNonces := make(map[string]int, len(vaultsDataFile)*16)
+	// .dr files carry a reshare nonce (unlike the legacy mnemonic-encrypted JSON below, one .dr
+	// file is one device's shares for one specific epoch), so they're grouped by vault+nonce here
+	// and folded in below once every input file has been seen, picking the highest nonce the same
+	// way the legacy path does.
+	drSharesByVaultNonce := make(map[string]map[int]*drVaultShares, len(vaultsDataFile))
 
 	// // Do the main routine
 	for _, file := range vaultsDataFile {
 		if strings.EqualFold(filepath.Ext(file.File), ".dr") {
-			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults,
-				clearVaults, vaultAllSharesECDSA, vaultAllSharesEDDSA, vaultHasEDDSA); err != nil {
+			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults, drSharesByVaultNonce); err != nil {
 				welp = err
 				return
 			}
@@ -98,30 +102,15 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 			}
 
 			// take the highest reshareNonce we have saved (best effort)
-			lastReshareNonce := -1
+			nonces := make(map[int]bool, len(resharesMap))
 			for nonce := range resharesMap {
-				// support the -nonce flag to override the last reshare nonce we use
-				if !justListingVaults && nonceOverride != nil && *nonceOverride > -1 && *nonceOverride != nonce {
-					continue
-				}
-				if nonce > lastReshareNonce {
-					lastReshareNonce = nonce
-				}
+				nonces[nonce] = true
 			}
+			lastReshareNonce := pickLastReshareNonce(nonces, vID, clearVaults, nonceOverride, justListingVaults, vaultLastNonces)
 			if lastReshareNonce == -1 {
 				//welp = fmt.Errorf("⚠ no share data found for vault `%s` in save file", vID)
 				continue // not a show stopper
 			}
-			if glbLastReShareNonce, ok := vaultLastNonces[vID]; ok && glbLastReShareNonce != lastReshareNonce {
-				vaultName := clearVaults[vID].Name
-				fmt.Println(ui.PlainTextf("\n⚠ Non matching reshare nonce for vault `%s`. You may have to specify prior reshare config with -nonce and -threshold when recovering that vault", vaultName))
-				if lastReshareNonce-1 >= 0 {
-					fmt.Println(ui.PlainTextf("⚠ If you have problems recovering that vault, you could try: -vault-id %s -nonce %d -threshold x. Replace x with previous vault threshold.", vID, lastReshareNonce-1))
-				} else {
-					println()
-				}
-			}
-			vaultLastNonces[vID] = lastReshareNonce
 			cipheredVault := resharesMap[lastReshareNonce]
 
 			// DECRYPT
@@ -218,6 +207,32 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		}
 
 		clear(aesKey32)
+	}
+
+	// Fold in the .dr shares accumulated above: for each vault, pick the highest reshare nonce
+	// (or -nonce override) the same way the legacy mnemonic-encrypted JSON path does, warning on
+	// cross-file nonce disagreement, then merge that epoch's shares into the same pools used by
+	// the legacy path so a single recovery run can mix both file formats for a vault.
+	for vID, byNonce := range drSharesByVaultNonce {
+		nonces := make(map[int]bool, len(byNonce))
+		for nonce := range byNonce {
+			nonces[nonce] = true
+		}
+		lastReshareNonce := pickLastReshareNonce(nonces, vID, clearVaults, nonceOverride, justListingVaults, vaultLastNonces)
+		if lastReshareNonce == -1 {
+			continue
+		}
+		chosen := byNonce[lastReshareNonce]
+		if err := ensureClearVaultThreshold(clearVaults, vID, chosen.threshold,
+			fmt.Sprintf(".dr files for vault %s at reshare nonce %d", vID, lastReshareNonce)); err != nil {
+			welp = err
+			return
+		}
+		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], chosen.ecdsa...)
+		if chosen.hasEdDSA {
+			vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], chosen.eddsa...)
+			vaultHasEDDSA[vID] = true
+		}
 	}
 
 	// populate vault IDs
@@ -369,8 +384,7 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 // share pools the legacy mnemonic-encrypted path populates, so a single recovery run can mix both
 // file formats for the same vault.
 func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListingVaults bool,
-	clearVaults ClearVaultMap, vaultAllSharesECDSA VaultAllSharesECDSA, vaultAllSharesEDDSA VaultAllSharesEdDSA,
-	vaultHasEDDSA map[string]bool) error {
+	drSharesByVaultNonce map[string]map[int]*drVaultShares) error {
 
 	if len(privateKeyPEM) == 0 {
 		return fmt.Errorf("⚠ %s is a Virtual Signer .dr file; use -private-key to supply the ML-KEM-768 private key PEM", path)
@@ -386,6 +400,8 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 		return fmt.Errorf("⚠ failed to decrypt %s: %s", path, err)
 	}
 
+	// The reconstructed vault ID and threshold come from the decrypted (AEAD-authenticated)
+	// payload, not the plaintext envelope fields, since the latter aren't tamper-evident.
 	var vID string
 	var threshold int
 	switch parsed.Kind {
@@ -399,9 +415,23 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 	if !justListingVaults && vID != *vaultID {
 		return nil
 	}
+	if threshold < 1 {
+		return fmt.Errorf("⚠ %s does not carry a valid threshold", path)
+	}
 
-	if err := ensureClearVaultThreshold(clearVaults, vID, threshold, path); err != nil {
-		return err
+	nonce := int(parsed.Envelope.ReshareNonce)
+	byNonce, ok := drSharesByVaultNonce[vID]
+	if !ok {
+		byNonce = make(map[int]*drVaultShares)
+		drSharesByVaultNonce[vID] = byNonce
+	}
+	entry, ok := byNonce[nonce]
+	if !ok {
+		entry = &drVaultShares{threshold: threshold}
+		byNonce[nonce] = entry
+	} else if entry.threshold != threshold {
+		return fmt.Errorf("⚠ %s: threshold %d disagrees with another .dr file at the same reshare nonce %d for vault %s (%d)",
+			path, threshold, nonce, vID, entry.threshold)
 	}
 
 	switch parsed.Kind {
@@ -410,16 +440,53 @@ func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListi
 		if err != nil {
 			return fmt.Errorf("⚠ %s: %s", path, err)
 		}
-		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], shares...)
+		entry.ecdsa = append(entry.ecdsa, shares...)
 	case dr.KindEdDSA:
 		shares, err := parsed.EdDSA.ToEdDSASaveData()
 		if err != nil {
 			return fmt.Errorf("⚠ %s: %s", path, err)
 		}
-		vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], shares...)
-		vaultHasEDDSA[vID] = true
+		entry.eddsa = append(entry.eddsa, shares...)
+		entry.hasEdDSA = true
 	}
 	return nil
+}
+
+// pickLastReshareNonce selects the reshare nonce to use for a vault from the set of nonces found
+// across its input files (honoring the -nonce override), warning if it disagrees with the nonce
+// already picked for this vault from another input file. Shared by the legacy mnemonic-encrypted
+// JSON path and the Virtual Signer .dr JSON path so multi-epoch inputs are handled consistently
+// regardless of file format. Returns -1 if no nonce survives the override filter.
+func pickLastReshareNonce(nonces map[int]bool, vID string, clearVaults ClearVaultMap, nonceOverride *int,
+	justListingVaults bool, vaultLastNonces map[string]int) int {
+
+	lastReshareNonce := -1
+	for nonce := range nonces {
+		// support the -nonce flag to override the last reshare nonce we use
+		if !justListingVaults && nonceOverride != nil && *nonceOverride > -1 && *nonceOverride != nonce {
+			continue
+		}
+		if nonce > lastReshareNonce {
+			lastReshareNonce = nonce
+		}
+	}
+	if lastReshareNonce == -1 {
+		return -1
+	}
+	if glbLastReShareNonce, ok := vaultLastNonces[vID]; ok && glbLastReShareNonce != lastReshareNonce {
+		vaultName := vID
+		if cv, ok2 := clearVaults[vID]; ok2 && cv != nil {
+			vaultName = cv.Name
+		}
+		fmt.Println(ui.PlainTextf("\n⚠ Non matching reshare nonce for vault `%s`. You may have to specify prior reshare config with -nonce and -threshold when recovering that vault", vaultName))
+		if lastReshareNonce-1 >= 0 {
+			fmt.Println(ui.PlainTextf("⚠ If you have problems recovering that vault, you could try: -vault-id %s -nonce %d -threshold x. Replace x with previous vault threshold.", vID, lastReshareNonce-1))
+		} else {
+			println()
+		}
+	}
+	vaultLastNonces[vID] = lastReshareNonce
+	return lastReshareNonce
 }
 
 // ensureClearVaultThreshold makes sure a ClearVault entry exists for a vault first seen via a .dr

--- a/tool.go
+++ b/tool.go
@@ -15,10 +15,12 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/data"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/dr"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/fileutils"
 	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
 	"github.com/binance-chain/tss-lib/crypto"
@@ -36,7 +38,7 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string) (
+func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride, quorumOverride *int, exportKSFile, passwordForKS *string, privateKeyPEM []byte) (
 	address string, ecdsaSK, eddsaSK []byte, orderedVaults []ui.VaultPickerItem, exportedKsFile *string, welp error) {
 
 	if nonceOverride != nil && *nonceOverride > -1 {
@@ -60,6 +62,15 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 
 	// // Do the main routine
 	for _, file := range vaultsDataFile {
+		if strings.EqualFold(filepath.Ext(file.File), ".dr") {
+			if err := processDRFile(file.File, privateKeyPEM, vaultID, justListingVaults,
+				clearVaults, vaultAllSharesECDSA, vaultAllSharesEDDSA, vaultHasEDDSA); err != nil {
+				welp = err
+				return
+			}
+			continue
+		}
+
 		saveData := new(SavedData)
 
 		content, err := os.ReadFile(file.File)
@@ -352,6 +363,83 @@ func runTool(vaultsDataFile []ui.VaultsDataFile, vaultID *string, nonceOverride,
 		fmt.Println(ui.PlainTextf("\nWrote a MetaMask wallet v3 (for ECDSA key only) to: %s\n", *exportKSFile))
 	}
 	return address, ecdsaSK, eddsaSK, orderedVaults, exportedKsFile, nil
+}
+
+// processDRFile decrypts a Virtual Signer .dr file and folds its shares into the same per-vault
+// share pools the legacy mnemonic-encrypted path populates, so a single recovery run can mix both
+// file formats for the same vault.
+func processDRFile(path string, privateKeyPEM []byte, vaultID *string, justListingVaults bool,
+	clearVaults ClearVaultMap, vaultAllSharesECDSA VaultAllSharesECDSA, vaultAllSharesEDDSA VaultAllSharesEdDSA,
+	vaultHasEDDSA map[string]bool) error {
+
+	if len(privateKeyPEM) == 0 {
+		return fmt.Errorf("⚠ %s is a Virtual Signer .dr file; use -private-key to supply the ML-KEM-768 private key PEM", path)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("⚠ failed to read file(%s): %s", path, err)
+	}
+
+	parsed, err := dr.DecryptAndParse(privateKeyPEM, raw)
+	if err != nil {
+		return fmt.Errorf("⚠ failed to decrypt %s: %s", path, err)
+	}
+
+	var vID string
+	var threshold int
+	switch parsed.Kind {
+	case dr.KindECDSA:
+		vID, threshold = parsed.ECDSA.VaultId, parsed.ECDSA.Threshold
+	case dr.KindEdDSA:
+		vID, threshold = parsed.EdDSA.VaultId, parsed.EdDSA.Threshold
+	}
+
+	// only look at the vault we're interested in, if one was supplied
+	if !justListingVaults && vID != *vaultID {
+		return nil
+	}
+
+	if err := ensureClearVaultThreshold(clearVaults, vID, threshold, path); err != nil {
+		return err
+	}
+
+	switch parsed.Kind {
+	case dr.KindECDSA:
+		shares, err := parsed.ECDSA.ToECDSASaveData()
+		if err != nil {
+			return fmt.Errorf("⚠ %s: %s", path, err)
+		}
+		vaultAllSharesECDSA[vID] = append(vaultAllSharesECDSA[vID], shares...)
+	case dr.KindEdDSA:
+		shares, err := parsed.EdDSA.ToEdDSASaveData()
+		if err != nil {
+			return fmt.Errorf("⚠ %s: %s", path, err)
+		}
+		vaultAllSharesEDDSA[vID] = append(vaultAllSharesEDDSA[vID], shares...)
+		vaultHasEDDSA[vID] = true
+	}
+	return nil
+}
+
+// ensureClearVaultThreshold makes sure a ClearVault entry exists for a vault first seen via a .dr
+// file (which carries no vault Name, only a VaultId), and errors out if a .dr file's threshold
+// disagrees with a threshold already established for this vault from another input file.
+func ensureClearVaultThreshold(clearVaults ClearVaultMap, vID string, threshold int, path string) error {
+	if threshold < 1 {
+		return fmt.Errorf("⚠ %s does not carry a valid threshold", path)
+	}
+	existing, ok := clearVaults[vID]
+	if !ok {
+		clearVaults[vID] = &ClearVault{Name: vID, Quroum: threshold}
+		return nil
+	}
+	if existing.Quroum != 0 && existing.Quroum != threshold {
+		return fmt.Errorf("⚠ vault %s: threshold mismatch between input files (%d vs %d). "+
+			"Make sure all supplied files are from the same vault epoch", vID, existing.Quroum, threshold)
+	}
+	existing.Quroum = threshold
+	return nil
 }
 
 func inflateSharesForCurve[T SaveData](shares []string, justListingVaults bool) ([]*T, error) {

--- a/tool_dr_test.go
+++ b/tool_dr_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/mlkem"
 	"crypto/rand"
 	"crypto/sha512"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -141,11 +142,27 @@ func writeLegacyVaultFile(t *testing.T, dir, name, mnemonic, vaultID string, non
 	return path
 }
 
+// oidMLKEM768Test is the ML-KEM-768 algorithm identifier (RFC 9935 / NIST CSOR
+// 2.16.840.1.101.3.4.4.2) used to wrap generated seeds in the standard
+// PKCS#8 PrivateKeyInfo DER structure that OpenSSL 3.5+ and current
+// key-generation tooling produce.
+var oidMLKEM768Test = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 4, 2}
+
 func genMLKEMKeyPEM(t *testing.T) (priv *mlkem.DecapsulationKey768, privPEM []byte) {
 	t.Helper()
 	priv, err := mlkem.GenerateKey768()
 	require.NoError(t, err)
-	privPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv.Bytes()})
+
+	der, err := asn1.Marshal(struct {
+		Version    int
+		Algo       struct{ Algorithm asn1.ObjectIdentifier }
+		PrivateKey []byte
+	}{
+		Algo:       struct{ Algorithm asn1.ObjectIdentifier }{oidMLKEM768Test},
+		PrivateKey: priv.Bytes(),
+	})
+	require.NoError(t, err)
+	privPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
 	return priv, privPEM
 }
 

--- a/tool_dr_test.go
+++ b/tool_dr_test.go
@@ -51,14 +51,19 @@ func encryptDRForTest(t *testing.T, pub *mlkem.EncapsulationKey768, plaintext []
 	return append(cipherTextKEM, sealed...)
 }
 
-// writeDRFile JSON-marshals payload, encrypts it as a .dr file under dir/name, and returns its path.
-func writeDRFile(t *testing.T, dir, name string, pub *mlkem.EncapsulationKey768, payload any) string {
+// writeDRFile JSON-marshals payload, encrypts it, wraps it in a dr.FileEnvelope (meta's
+// plaintext fields plus the resulting base64 ciphertext as DataB64), and writes it as a .dr file
+// under dir/name. Returns the file's path.
+func writeDRFile(t *testing.T, dir, name string, pub *mlkem.EncapsulationKey768, meta dr.FileEnvelope, payload any) string {
 	t.Helper()
 	plaintext, err := json.Marshal(payload)
 	require.NoError(t, err)
-	raw := encryptDRForTest(t, pub, plaintext)
+	ciphertext := encryptDRForTest(t, pub, plaintext)
+	meta.DataB64 = base64.StdEncoding.EncodeToString(ciphertext)
+	content, err := json.Marshal(meta)
+	require.NoError(t, err)
 	path := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	require.NoError(t, os.WriteFile(path, content, 0o600))
 	return path
 }
 
@@ -184,7 +189,8 @@ func TestTool_DR_ECDSA_And_EdDSA_Recovery(t *testing.T) {
 			VaultId:   vaultID,
 			Threshold: threshold,
 		}
-		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.ecdsa.secp256k1.dr", i), priv.EncapsulationKey(), payload)
+		meta := dr.FileEnvelope{VaultId: vaultID, RequestId: fmt.Sprintf("req%d", i), ReshareNonce: 1, Algo: "ECDSA", Curve: "secp256k1"}
+		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.ecdsa.secp256k1.dr", i), priv.EncapsulationKey(), meta, payload)
 		files = append(files, ui.VaultsDataFile{File: path})
 	}
 	for i := 0; i < n; i++ {
@@ -193,7 +199,8 @@ func TestTool_DR_ECDSA_And_EdDSA_Recovery(t *testing.T) {
 			VaultId:   vaultID,
 			Threshold: threshold,
 		}
-		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.eddsa.ed25519.dr", i), priv.EncapsulationKey(), payload)
+		meta := dr.FileEnvelope{VaultId: vaultID, RequestId: fmt.Sprintf("req%d", i), ReshareNonce: 1, Algo: "EDDSA", Curve: "ed25519"}
+		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.eddsa.ed25519.dr", i), priv.EncapsulationKey(), meta, payload)
 		files = append(files, ui.VaultsDataFile{File: path})
 	}
 
@@ -217,21 +224,25 @@ func TestTool_DR_ThresholdMismatch(t *testing.T) {
 
 	_, pub, shares := makeVSSSharesS256(t, 2, 3)
 
-	path1 := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
-		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
-		VaultId:   vaultID,
-		Threshold: 2,
-	})
-	path2 := writeDRFile(t, dirTmp, "req1.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
-		Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
-		VaultId:   vaultID,
-		Threshold: 3, // deliberately different
-	})
+	path1 := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(),
+		dr.FileEnvelope{VaultId: vaultID, RequestId: "req0", ReshareNonce: 1, Algo: "ECDSA", Curve: "secp256k1"},
+		&dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+			VaultId:   vaultID,
+			Threshold: 2,
+		})
+	path2 := writeDRFile(t, dirTmp, "req1.ecdsa.secp256k1.dr", priv.EncapsulationKey(),
+		dr.FileEnvelope{VaultId: vaultID, RequestId: "req1", ReshareNonce: 1, Algo: "ECDSA", Curve: "secp256k1"},
+		&dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+			VaultId:   vaultID,
+			Threshold: 3, // deliberately different
+		})
 
 	files := []ui.VaultsDataFile{{File: path1}, {File: path2}}
 	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, privPEM)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "threshold mismatch")
+	require.Contains(t, err.Error(), "disagrees with another .dr file")
 }
 
 func TestTool_DR_MissingPrivateKey(t *testing.T) {
@@ -240,11 +251,13 @@ func TestTool_DR_MissingPrivateKey(t *testing.T) {
 	vaultID := "dr-test-vault-nokey"
 
 	_, pub, shares := makeVSSSharesS256(t, 2, 2)
-	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
-		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
-		VaultId:   vaultID,
-		Threshold: 2,
-	})
+	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(),
+		dr.FileEnvelope{VaultId: vaultID, RequestId: "req0", ReshareNonce: 1, Algo: "ECDSA", Curve: "secp256k1"},
+		&dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+			VaultId:   vaultID,
+			Threshold: 2,
+		})
 
 	files := []ui.VaultsDataFile{{File: path}}
 	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
@@ -259,11 +272,13 @@ func TestTool_DR_WrongPrivateKey(t *testing.T) {
 	vaultID := "dr-test-vault-wrongkey"
 
 	_, pub, shares := makeVSSSharesS256(t, 2, 2)
-	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
-		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
-		VaultId:   vaultID,
-		Threshold: 2,
-	})
+	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(),
+		dr.FileEnvelope{VaultId: vaultID, RequestId: "req0", ReshareNonce: 1, Algo: "ECDSA", Curve: "secp256k1"},
+		&dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+			VaultId:   vaultID,
+			Threshold: 2,
+		})
 
 	files := []ui.VaultsDataFile{{File: path}}
 	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, wrongPEM)
@@ -287,12 +302,15 @@ func TestTool_DR_MixedWithLegacy(t *testing.T) {
 	require.NoError(t, err)
 	legacyPath := writeLegacyVaultFile(t, dirTmp, "legacy.json", mmI, vaultID, 0, threshold, []string{string(legacyShareJSON)})
 
-	// Share 1 goes into a .dr file.
-	drPath := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
-		Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
-		VaultId:   vaultID,
-		Threshold: threshold,
-	})
+	// Share 1 goes into a .dr file, at the same reshare nonce (0) as the legacy file above so
+	// they're recognized as the same epoch and folded together.
+	drPath := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(),
+		dr.FileEnvelope{VaultId: vaultID, RequestId: "req0", ReshareNonce: 0, Algo: "ECDSA", Curve: "secp256k1"},
+		&dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+			VaultId:   vaultID,
+			Threshold: threshold,
+		})
 
 	files := []ui.VaultsDataFile{
 		{File: legacyPath, Mnemonics: mmI},

--- a/tool_dr_test.go
+++ b/tool_dr_test.go
@@ -1,0 +1,291 @@
+// Copyright (C) 2021 io finnet group, inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Full license text available in LICENSE file in repository root.
+
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/elliptic"
+	"crypto/mlkem"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/dr"
+	"github.com/IoFinnet/io-vault-disaster-recovery-cli/internal/ui"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/crypto/vss"
+	ecdsa_keygen "github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/binance-chain/tss-lib/tss"
+	"github.com/stretchr/testify/require"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// --- .dr file fixture helpers -----------------------------------------------------------------
+
+// encryptDRForTest encrypts plaintext into the .dr wire format with the given ML-KEM-768 public
+// key, mirroring the Virtual Signer's EncryptingMarshallerForDR envelope.
+func encryptDRForTest(t *testing.T, pub *mlkem.EncapsulationKey768, plaintext []byte) []byte {
+	t.Helper()
+	sharedSecret, cipherTextKEM := pub.Encapsulate()
+	blk, err := aes.NewCipher(sharedSecret)
+	require.NoError(t, err)
+	aesGCM, err := cipher.NewGCM(blk)
+	require.NoError(t, err)
+	nonce := make([]byte, aesGCM.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonce)
+	require.NoError(t, err)
+	sealed := aesGCM.Seal(nonce, nonce, plaintext, nil)
+	return append(cipherTextKEM, sealed...)
+}
+
+// writeDRFile JSON-marshals payload, encrypts it as a .dr file under dir/name, and returns its path.
+func writeDRFile(t *testing.T, dir, name string, pub *mlkem.EncapsulationKey768, payload any) string {
+	t.Helper()
+	plaintext, err := json.Marshal(payload)
+	require.NoError(t, err)
+	raw := encryptDRForTest(t, pub, plaintext)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	return path
+}
+
+func ecPointMirror(curveName string, p *crypto.ECPoint) *dr.ECPoint {
+	return &dr.ECPoint{Curve: curveName, Coords: [2]*big.Int{p.X(), p.Y()}}
+}
+
+// makeVSSShares creates n real Shamir/Feldman VSS shares of a random secret over ec, requiring
+// `threshold` of them to reconstruct (i.e. polynomial degree threshold-1), plus the public key.
+func makeVSSShares(t *testing.T, ec elliptic.Curve, threshold, n int) (secret *big.Int, pub *crypto.ECPoint, shares vss.Shares) {
+	t.Helper()
+	sec, err := rand.Int(rand.Reader, ec.Params().N)
+	require.NoError(t, err)
+	require.NotZero(t, sec.Sign())
+
+	indexes := make([]*big.Int, n)
+	for i := range indexes {
+		indexes[i] = big.NewInt(int64(i + 1))
+	}
+	v, s, err := vss.Create(ec, threshold-1, sec, indexes)
+	require.NoError(t, err)
+	return sec, v[0], s
+}
+
+func makeVSSSharesS256(t *testing.T, threshold, n int) (*big.Int, *crypto.ECPoint, vss.Shares) {
+	return makeVSSShares(t, tss.S256(), threshold, n)
+}
+
+func makeVSSSharesEdwards(t *testing.T, threshold, n int) (*big.Int, *crypto.ECPoint, vss.Shares) {
+	return makeVSSShares(t, tss.Edwards(), threshold, n)
+}
+
+// --- legacy (mnemonic-encrypted) fixture helper, for the mixed-format test -------------------
+
+// writeLegacyVaultFile builds a legacy-format SavedData JSON file (AES-256-GCM, mnemonic-derived
+// key) carrying the given ECDSA shares for one vault/nonce, and returns its path.
+func writeLegacyVaultFile(t *testing.T, dir, name, mnemonic, vaultID string, nonce, threshold int, ecdsaShareJSONs []string) string {
+	t.Helper()
+
+	clearVault := ClearVault{
+		Name:   "mixed-format-test-vault",
+		Quroum: threshold,
+		Curves: []ClearVaultCurve{{Algorithm: "ECDSA", Shares: ecdsaShareJSONs}},
+	}
+	plaintext, err := json.Marshal(clearVault)
+	require.NoError(t, err)
+
+	aesKey32, err := bip39.EntropyFromMnemonic(mnemonic)
+	require.NoError(t, err)
+
+	blk, err := aes.NewCipher(aesKey32)
+	require.NoError(t, err)
+	aesGCM, err := cipher.NewGCM(blk)
+	require.NoError(t, err)
+	nonceBz := make([]byte, aesGCM.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonceBz)
+	require.NoError(t, err)
+	sealed := aesGCM.Seal(nil, nonceBz, plaintext, nil)
+	ctLen := len(sealed) - aesGCM.Overhead()
+	ciphertext, tag := sealed[:ctLen], sealed[ctLen:]
+
+	hash := sha512.Sum512(plaintext)
+
+	savedData := SavedData{
+		Vaults: map[string]CipheredVaultMap{
+			vaultID: {
+				nonce: CipheredVault{
+					CipherTextB64: base64.StdEncoding.EncodeToString(ciphertext),
+					CipherParams:  CipherParams{IV: hex.EncodeToString(nonceBz), Tag: hex.EncodeToString(tag)},
+					Cipher:        "aes-256-gcm",
+					Hash:          hex.EncodeToString(hash[:]),
+				},
+			},
+		},
+	}
+	content, err := json.Marshal(savedData)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
+}
+
+func genMLKEMKeyPEM(t *testing.T) (priv *mlkem.DecapsulationKey768, privPEM []byte) {
+	t.Helper()
+	priv, err := mlkem.GenerateKey768()
+	require.NoError(t, err)
+	privPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: priv.Bytes()})
+	return priv, privPEM
+}
+
+// --- tests -------------------------------------------------------------------------------------
+
+func TestTool_DR_ECDSA_And_EdDSA_Recovery(t *testing.T) {
+	dirTmp := t.TempDir()
+	priv, privPEM := genMLKEMKeyPEM(t)
+	vaultID := "dr-test-vault-1"
+	const threshold, n = 2, 3
+
+	ecdsaSecret, ecdsaPub, ecdsaShares := makeVSSSharesS256(t, threshold, n)
+	eddsaSecret, eddsaPub, eddsaShares := makeVSSSharesEdwards(t, threshold, n)
+
+	var files []ui.VaultsDataFile
+	for i := 0; i < n; i++ {
+		payload := &dr.ECDSASharesAndVaultId{
+			Data:      []*dr.ECDSAShare{{Xi: ecdsaShares[i].Share, ShareID: ecdsaShares[i].ID, ECDSAPub: ecPointMirror("secp256k1", ecdsaPub)}},
+			VaultId:   vaultID,
+			Threshold: threshold,
+		}
+		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.ecdsa.secp256k1.dr", i), priv.EncapsulationKey(), payload)
+		files = append(files, ui.VaultsDataFile{File: path})
+	}
+	for i := 0; i < n; i++ {
+		payload := &dr.EdDSASharesAndVaultId{
+			Data:      []*dr.EdDSAShare{{Xi: eddsaShares[i].Share, ShareID: eddsaShares[i].ID, EDDSAPub: ecPointMirror("ed25519", eddsaPub)}},
+			VaultId:   vaultID,
+			Threshold: threshold,
+		}
+		path := writeDRFile(t, dirTmp, fmt.Sprintf("req%d.eddsa.ed25519.dr", i), priv.EncapsulationKey(), payload)
+		files = append(files, ui.VaultsDataFile{File: path})
+	}
+
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, privPEM)
+	require.NoError(t, err)
+	require.Len(t, vaultsFormData, 1)
+	require.Equal(t, vaultID, vaultsFormData[0].VaultID)
+	require.Equal(t, threshold, vaultsFormData[0].Quorum)
+
+	_, expectedAddress, err := getTSSPubKeyForEthereum(ecdsaPub.X(), ecdsaPub.Y())
+	require.NoError(t, err)
+	require.Equal(t, expectedAddress, address)
+	require.Equal(t, hex.EncodeToString(leftPadTo32Bytes(ecdsaSecret)), hex.EncodeToString(ecSK))
+	require.Equal(t, hex.EncodeToString(leftPadTo32Bytes(eddsaSecret)), hex.EncodeToString(edSK))
+}
+
+func TestTool_DR_ThresholdMismatch(t *testing.T) {
+	dirTmp := t.TempDir()
+	priv, privPEM := genMLKEMKeyPEM(t)
+	vaultID := "dr-test-vault-mismatch"
+
+	_, pub, shares := makeVSSSharesS256(t, 2, 3)
+
+	path1 := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
+		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+		VaultId:   vaultID,
+		Threshold: 2,
+	})
+	path2 := writeDRFile(t, dirTmp, "req1.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
+		Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+		VaultId:   vaultID,
+		Threshold: 3, // deliberately different
+	})
+
+	files := []ui.VaultsDataFile{{File: path1}, {File: path2}}
+	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, privPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "threshold mismatch")
+}
+
+func TestTool_DR_MissingPrivateKey(t *testing.T) {
+	dirTmp := t.TempDir()
+	priv, _ := genMLKEMKeyPEM(t)
+	vaultID := "dr-test-vault-nokey"
+
+	_, pub, shares := makeVSSSharesS256(t, 2, 2)
+	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
+		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+		VaultId:   vaultID,
+		Threshold: 2,
+	})
+
+	files := []ui.VaultsDataFile{{File: path}}
+	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-private-key")
+}
+
+func TestTool_DR_WrongPrivateKey(t *testing.T) {
+	dirTmp := t.TempDir()
+	priv, _ := genMLKEMKeyPEM(t)
+	_, wrongPEM := genMLKEMKeyPEM(t)
+	vaultID := "dr-test-vault-wrongkey"
+
+	_, pub, shares := makeVSSSharesS256(t, 2, 2)
+	path := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
+		Data:      []*dr.ECDSAShare{{Xi: shares[0].Share, ShareID: shares[0].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+		VaultId:   vaultID,
+		Threshold: 2,
+	})
+
+	files := []ui.VaultsDataFile{{File: path}}
+	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, wrongPEM)
+	require.Error(t, err)
+}
+
+func TestTool_DR_MixedWithLegacy(t *testing.T) {
+	dirTmp := t.TempDir()
+	priv, privPEM := genMLKEMKeyPEM(t)
+	vaultID := "dr-test-vault-mixed"
+	const threshold, n = 2, 2 // one share from legacy, one from .dr
+
+	secret, pub, shares := makeVSSSharesS256(t, threshold, n)
+
+	// Share 0 goes into a legacy mnemonic-encrypted vault file.
+	legacyShareData := &ecdsa_keygen.LocalPartySaveData{
+		LocalSecrets: ecdsa_keygen.LocalSecrets{Xi: shares[0].Share, ShareID: shares[0].ID},
+		ECDSAPub:     pub,
+	}
+	legacyShareJSON, err := json.Marshal(legacyShareData)
+	require.NoError(t, err)
+	legacyPath := writeLegacyVaultFile(t, dirTmp, "legacy.json", mmI, vaultID, 0, threshold, []string{string(legacyShareJSON)})
+
+	// Share 1 goes into a .dr file.
+	drPath := writeDRFile(t, dirTmp, "req0.ecdsa.secp256k1.dr", priv.EncapsulationKey(), &dr.ECDSASharesAndVaultId{
+		Data:      []*dr.ECDSAShare{{Xi: shares[1].Share, ShareID: shares[1].ID, ECDSAPub: ecPointMirror("secp256k1", pub)}},
+		VaultId:   vaultID,
+		Threshold: threshold,
+	})
+
+	files := []ui.VaultsDataFile{
+		{File: legacyPath, Mnemonics: mmI},
+		{File: drPath},
+	}
+	address, ecSK, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, privPEM)
+	require.NoError(t, err)
+
+	_, expectedAddress, err := getTSSPubKeyForEthereum(pub.X(), pub.Y())
+	require.NoError(t, err)
+	require.Equal(t, expectedAddress, address)
+	require.Equal(t, hex.EncodeToString(leftPadTo32Bytes(secret)), hex.EncodeToString(ecSK))
+}

--- a/tool_test.go
+++ b/tool_test.go
@@ -43,7 +43,7 @@ func TestTool_New_V2_List(t *testing.T) {
 	}
 
 	// use the correct file path for tests
-	address, ecSK, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -89,7 +89,7 @@ func TestTool_New_V2_Export_lqns(t *testing.T) {
 		{File: "./test-files/new_u44.json", Mnemonics: mmNewU44},
 	}
 
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -117,7 +117,7 @@ func TestTool_NewSingle_V2_List(t *testing.T) {
 		{File: "./test-files/new_single.json", Mnemonics: mmNewSingle},
 	}
 	// use the correct file path for tests
-	address, _, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, _, edSK, vaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -141,7 +141,7 @@ func TestTool_NewSingle_V2_List_BadMnemonic(t *testing.T) {
 		{File: "./test-files/new_single.json", Mnemonics: mmV2},
 	}
 	// use the correct file path for tests
-	_, _, _, _, _, err := runTool(files, nil, nil, nil, nil, nil)
+	_, _, _, _, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -154,7 +154,7 @@ func TestTool_NewSingle_V2_Export_qvl5(t *testing.T) {
 	files := []ui.VaultsDataFile{
 		{File: "./test-files/new_single.json", Mnemonics: mmNewSingle},
 	}
-	_, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	_, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -181,7 +181,7 @@ func TestTool_NewSingle_V2_Export_qvl5_BadMnemonic(t *testing.T) {
 	files := []ui.VaultsDataFile{
 		{File: "./test-files/new_single.json", Mnemonics: mmV2},
 	}
-	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	_, _, _, _, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -193,7 +193,7 @@ func TestTool_Legacy_V2_List(t *testing.T) {
 	}
 
 	// use the correct file path for tests
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -219,7 +219,7 @@ func TestTool_Legacy_V2_Export_c20x(t *testing.T) {
 		{File: "./test-files/v2.json", Mnemonics: mmV2},
 	}
 
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -249,7 +249,7 @@ func TestTool_Legacy_V1_IL_List(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -279,7 +279,7 @@ func TestTool_Legacy_V1_IL_Export_m0k(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 
 	if !assert.NoError(t, err) {
 		return
@@ -312,7 +312,7 @@ func TestTool_Legacy_V1_ILM_List(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -343,7 +343,7 @@ func TestTool_Legacy_V1_ILM_Export_m0k(t *testing.T) {
 		{File: "./test-files/l.json", Mnemonics: mmL},
 	}
 
-	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	address, ecSK, edSK, vaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 
 	if !assert.NoError(t, err) {
 		return
@@ -404,7 +404,7 @@ func TestZipFileProcessing_V2_List(t *testing.T) {
 	}
 
 	// Run the tool to list vaults - this is what we're comparing to
-	address, ecSK, edSK, expectedVaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil)
+	address, ecSK, edSK, expectedVaultFormData, _, err := runTool(files, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// The test has passed if we got to this point - the ZIP file handler worked
@@ -474,7 +474,7 @@ func TestZipFileProcessing_V2_Export_lqns(t *testing.T) {
 	}
 
 	// Run the tool with regular files first to get expected result
-	expectedAddress, expectedEcSK, expectedEdSK, expectedVaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil)
+	expectedAddress, expectedEcSK, expectedEdSK, expectedVaultsFormData, _, err := runTool(files, &vaultID, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, expectedVaultsFormData, 1)
 

--- a/types.go
+++ b/types.go
@@ -43,6 +43,15 @@ type (
 	VaultAllSharesECDSA map[string][]*ecdsa_keygen.LocalPartySaveData
 	VaultAllSharesEdDSA map[string][]*eddsa_keygen.LocalPartySaveData
 
+	// drVaultShares accumulates one reshare epoch's worth of .dr shares for a vault (one .dr file
+	// per device per algorithm), pending the "pick the highest nonce" selection in runTool.
+	drVaultShares struct {
+		threshold int
+		ecdsa     []*ecdsa_keygen.LocalPartySaveData
+		eddsa     []*eddsa_keygen.LocalPartySaveData
+		hasEdDSA  bool
+	}
+
 	SaveData interface {
 	}
 )


### PR DESCRIPTION
```
feat: VS disaster recovery [BONY-1344]
```

[BONY-1344](https://iofinnet.atlassian.net/browse/BONY-1344)

### Description:
The VS disaster recovery consumes .dr files. These are files encrypted with a ML-KEM-768 public key by the Virtual Signer (this logic is not in this project). The disaster recovery CLI is changed to take these encrypted .dr files containing share material and to decrypt these using the respective ML-KEM-768 private key provided by the user. A sample POSIX script is included here to generate the key pair calling the standard `openssl` command. Manually tested with .dr files.
 
…

#### Demos:

| Before | After |
| ------ | ----- |
|        |       |

### Breaking changes:

- [ ]

### New features:

- [x] VS disaster recovery

### Fixes:

- [ ]

### PR status:

- [ ] Tests added or updated
- [ ] Readme updated
- [ ] Public API Documentation updates

### REMEMBER: Steps after deployment

- [ ] When the GQL schema changes, it must be merged in the supergraph schema in Appsync: [steps to do it](https://github.com/IoFinnet/io-vault-cldsvc-gql-backend)

[BONY-1344]: https://iofinnet.atlassian.net/browse/BONY-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BONY-1344]: https://iofinnet.atlassian.net/browse/BONY-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recovery support for Virtual Signer `.dr` backup files alongside existing recovery inputs, including mixed `.dr` and legacy vault recovery.
  * Added `-private-key` CLI support for decrypting `.dr` files (ML-KEM-768 key PEM).
  * Recovery now validates `.dr` inputs as encrypted blobs and enforces threshold consistency across `.dr` files for the same vault/epoch.

* **Documentation**
  * Updated usage and ZIP guidance to include `.dr` files, clarify the flat ZIP layout, and prevent invalid input combinations.

* **Chores**
  * Added a POSIX script to generate ML-KEM-768 key pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->